### PR TITLE
커뮤니티 카테고리, 게시글 목록 및 게시글 상세 조회 기능 구현

### DIFF
--- a/src/main/java/com/example/mockvoting/domain/community/controller/CommunityController.java
+++ b/src/main/java/com/example/mockvoting/domain/community/controller/CommunityController.java
@@ -1,0 +1,61 @@
+package com.example.mockvoting.domain.community.controller;
+
+import com.example.mockvoting.domain.community.dto.CategoryResponseDTO;
+import com.example.mockvoting.domain.community.dto.PostSummaryResponseDTO;
+import com.example.mockvoting.domain.community.service.CommunityService;
+import com.example.mockvoting.response.ApiResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@Slf4j
+@RestController
+@RequestMapping("/api/community")
+@RequiredArgsConstructor
+public class CommunityController {
+    private final CommunityService communityService;
+
+    /**
+     *  게시글 카테고리 전체 조회
+     */
+    @GetMapping("/categories")
+    public ResponseEntity<ApiResponse<List<CategoryResponseDTO>>> getAllCategories() {
+        log.info("카테고리 전체 조회 요청");
+
+        try {
+            List<CategoryResponseDTO> categories = communityService.getAllCategories();
+            log.info("카테고리 전체 조회 성공");
+            return ResponseEntity.ok(ApiResponse.success("카테고리 전체 조회 성공", categories));
+        } catch (Exception e) {
+            log.error("카테고리 전체 조회 중 오류 발생", e);
+            return ResponseEntity.internalServerError()
+                    .body(ApiResponse.error("카테고리 전체 조회 실패"));
+        }
+    }
+
+    /**
+     *  카테고리별 게시글 조회
+     */
+    @GetMapping("/categories/{categoryCode}/posts")
+    public ResponseEntity<ApiResponse<Page<PostSummaryResponseDTO>>> getPostsByCategory(@PathVariable String categoryCode, Pageable pageable) {
+        log.info("카테고리 [{}]에 해당하는 게시글 목록 조회 요청", categoryCode);
+
+        try {
+            Page<PostSummaryResponseDTO> posts = communityService.getPostsByCategory(categoryCode, pageable);
+            log.info("카테고리 [{}] 게시글 목록 조회 성공", categoryCode);
+            return ResponseEntity.ok(ApiResponse.success("게시글 목록 조회 성공", posts));
+        } catch (Exception e) {
+            log.error("카테고리 [{}] 게시글 목록 조회 중 오류 발생", categoryCode, e);
+            return ResponseEntity.internalServerError()
+                    .body(ApiResponse.error("게시글 목록 조회 실패"));
+        }
+    }
+}

--- a/src/main/java/com/example/mockvoting/domain/community/controller/CommunityController.java
+++ b/src/main/java/com/example/mockvoting/domain/community/controller/CommunityController.java
@@ -1,6 +1,7 @@
 package com.example.mockvoting.domain.community.controller;
 
 import com.example.mockvoting.domain.community.dto.CategoryResponseDTO;
+import com.example.mockvoting.domain.community.dto.PostDetailResponseDTO;
 import com.example.mockvoting.domain.community.dto.PostSummaryResponseDTO;
 import com.example.mockvoting.domain.community.service.CommunityService;
 import com.example.mockvoting.response.ApiResponse;
@@ -58,4 +59,23 @@ public class CommunityController {
                     .body(ApiResponse.error("게시글 목록 조회 실패"));
         }
     }
+
+    /**
+     *  게시글 상세 조회
+     */
+    @GetMapping("/posts/{id}")
+    public ResponseEntity<ApiResponse<PostDetailResponseDTO>> getPostDetail(@PathVariable Integer id) {
+        log.info("게시글 [{}] 상세 조회 요청", id);
+
+        try {
+            PostDetailResponseDTO post = communityService.getPostDetail(id);
+            log.info("게시글 [{}] 상세 조회 성공", id);
+            return ResponseEntity.ok(ApiResponse.success("게시글 상세 조회 성공", post));
+        } catch (Exception e) {
+            log.error("게시글 [{}] 상세 조회 중 오류 발생", id, e);
+            return ResponseEntity.internalServerError()
+                    .body(ApiResponse.error("게시글 상세 조회 실패"));
+        }
+    }
+
 }

--- a/src/main/java/com/example/mockvoting/domain/community/dto/CategoryResponseDTO.java
+++ b/src/main/java/com/example/mockvoting/domain/community/dto/CategoryResponseDTO.java
@@ -1,0 +1,18 @@
+package com.example.mockvoting.domain.community.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class CategoryResponseDTO {
+    private Integer id;
+    private String code;
+    private String name;
+    private String description;
+    private Boolean isAnonymous;
+}

--- a/src/main/java/com/example/mockvoting/domain/community/dto/PostDetailResponseDTO.java
+++ b/src/main/java/com/example/mockvoting/domain/community/dto/PostDetailResponseDTO.java
@@ -1,0 +1,28 @@
+package com.example.mockvoting.domain.community.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class PostDetailResponseDTO {
+    private Integer id;
+    private Integer categoryId;
+    private String title;
+    private String content;
+    private String authorId;
+    private Integer voteCount;
+    private Integer views;
+    private LocalDateTime createdAt;
+    private LocalDateTime updatedAt;
+
+    private String categoryCode;
+    private String categoryName;
+    private String authorNickname;
+}

--- a/src/main/java/com/example/mockvoting/domain/community/dto/PostSummaryResponseDTO.java
+++ b/src/main/java/com/example/mockvoting/domain/community/dto/PostSummaryResponseDTO.java
@@ -1,0 +1,26 @@
+package com.example.mockvoting.domain.community.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class PostSummaryResponseDTO {
+    private Integer id;
+    private Integer categoryId;
+    private String title;
+    private String authorId;
+    private String thumbnailUrl;
+    private Integer voteCount;
+    private Integer views;
+    private LocalDateTime createdAt;
+
+    private String categoryName;
+    private String authorNickname;
+}

--- a/src/main/java/com/example/mockvoting/domain/community/mapper/CommunityMapper.java
+++ b/src/main/java/com/example/mockvoting/domain/community/mapper/CommunityMapper.java
@@ -1,6 +1,7 @@
 package com.example.mockvoting.domain.community.mapper;
 
 import com.example.mockvoting.domain.community.dto.CategoryResponseDTO;
+import com.example.mockvoting.domain.community.dto.PostDetailResponseDTO;
 import com.example.mockvoting.domain.community.dto.PostSummaryResponseDTO;
 import org.apache.ibatis.annotations.Mapper;
 import org.apache.ibatis.annotations.Param;
@@ -19,4 +20,7 @@ public interface CommunityMapper {
 
     // 카테고리별 게시글 개수 조회
     int selectPostCountByCategory(@Param("categoryCode") String categoryCode);
+
+    // 게시글 상세 조회
+    PostDetailResponseDTO selectPostDetailById(@Param("id") Integer id);
 }

--- a/src/main/java/com/example/mockvoting/domain/community/mapper/CommunityMapper.java
+++ b/src/main/java/com/example/mockvoting/domain/community/mapper/CommunityMapper.java
@@ -1,0 +1,22 @@
+package com.example.mockvoting.domain.community.mapper;
+
+import com.example.mockvoting.domain.community.dto.CategoryResponseDTO;
+import com.example.mockvoting.domain.community.dto.PostSummaryResponseDTO;
+import org.apache.ibatis.annotations.Mapper;
+import org.apache.ibatis.annotations.Param;
+
+import java.util.List;
+
+@Mapper
+public interface CommunityMapper {
+    // 게시글 카테고리 전체 조회
+    List<CategoryResponseDTO> selectAllCategories();
+
+    // 카테고리별 게시글 조회
+    List<PostSummaryResponseDTO> selectPostsByCategory(@Param("categoryCode") String categoryCode,
+                                                       @Param("offset") int offset,
+                                                       @Param("limit") int limit);
+
+    // 카테고리별 게시글 개수 조회
+    int selectPostCountByCategory(@Param("categoryCode") String categoryCode);
+}

--- a/src/main/java/com/example/mockvoting/domain/community/service/CommunityService.java
+++ b/src/main/java/com/example/mockvoting/domain/community/service/CommunityService.java
@@ -1,0 +1,42 @@
+package com.example.mockvoting.domain.community.service;
+
+import com.example.mockvoting.domain.community.dto.CategoryResponseDTO;
+import com.example.mockvoting.domain.community.dto.PostSummaryResponseDTO;
+import com.example.mockvoting.domain.community.mapper.CommunityMapper;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class CommunityService {
+    private final CommunityMapper communityMapper;
+
+    /**
+     *  게시글 카테고리 전체 조회
+     */
+    public List<CategoryResponseDTO> getAllCategories() {
+        return communityMapper.selectAllCategories();
+    }
+
+    /**
+     *  카테고리별 게시글 조회
+     */
+    public Page<PostSummaryResponseDTO> getPostsByCategory(String categoryCode, Pageable pageable) {
+        int offset = (int) pageable.getOffset();
+        int limit = (int) pageable.getPageSize();
+
+        List<PostSummaryResponseDTO> posts = communityMapper.selectPostsByCategory(categoryCode, offset, limit);
+        int total = communityMapper.selectPostCountByCategory(categoryCode);
+
+        return new PageImpl<>(posts, pageable, total);
+    }
+
+
+}

--- a/src/main/java/com/example/mockvoting/domain/community/service/CommunityService.java
+++ b/src/main/java/com/example/mockvoting/domain/community/service/CommunityService.java
@@ -1,6 +1,7 @@
 package com.example.mockvoting.domain.community.service;
 
 import com.example.mockvoting.domain.community.dto.CategoryResponseDTO;
+import com.example.mockvoting.domain.community.dto.PostDetailResponseDTO;
 import com.example.mockvoting.domain.community.dto.PostSummaryResponseDTO;
 import com.example.mockvoting.domain.community.mapper.CommunityMapper;
 import lombok.RequiredArgsConstructor;
@@ -38,5 +39,10 @@ public class CommunityService {
         return new PageImpl<>(posts, pageable, total);
     }
 
-
+    /**
+     *  게시글 상세 조회
+     */
+    public PostDetailResponseDTO getPostDetail(Integer id) {
+        return communityMapper.selectPostDetailById(id);
+    }
 }

--- a/src/main/resources/mapper/CommunityMapper.xml
+++ b/src/main/resources/mapper/CommunityMapper.xml
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+<mapper namespace="com.example.mockvoting.domain.community.mapper.CommunityMapper">
+    <!-- 게시글 카테고리 전체 조회 -->
+    <select id="selectAllCategories" resultType="com.example.mockvoting.domain.community.dto.CategoryResponseDTO">
+        SELECT
+            id,
+            code,
+            name,
+            description,
+            is_anonymous
+        FROM category
+        ORDER BY sort_order ASC
+    </select>
+
+    <!-- 카테고리별 게시글 조회 -->
+    <select id="selectPostsByCategory" resultType="com.example.mockvoting.domain.community.dto.PostSummaryResponseDTO">
+        SELECT
+            post.id,
+            post.category_id,
+            post.title,
+            post.author_id,
+            post.thumbnail_url,
+            (post.upvotes - post.downvotes) AS voteCount,
+            post.views,
+            post.created_at,
+            category.name AS categoryName,
+            user.nickname AS authorNickname
+        FROM post
+                 JOIN category ON post.category_id = category.id
+                 JOIN user ON post.author_id = user.user_id
+        WHERE category.code = #{categoryCode}
+          AND post.is_deleted = 0
+        ORDER BY post.created_at DESC
+        LIMIT #{limit} OFFSET #{offset}
+    </select>
+
+    <!-- 카테고리별 게시글 개수 조회 -->
+    <select id="selectPostCountByCategory" resultType="int">
+        SELECT COUNT(*)
+        FROM post
+                 JOIN category ON post.category_id = category.id
+        WHERE category.code = #{categoryCode}
+          AND post.is_deleted = 0
+    </select>
+
+</mapper>

--- a/src/main/resources/mapper/CommunityMapper.xml
+++ b/src/main/resources/mapper/CommunityMapper.xml
@@ -44,4 +44,25 @@
           AND post.is_deleted = 0
     </select>
 
+    <!-- 게시글 상세 조회 -->
+    <select id="selectPostDetailById" resultType="com.example.mockvoting.domain.community.dto.PostDetailResponseDTO">
+        SELECT
+            post.id,
+            post.category_id,
+            post.title,
+            post.content,
+            post.author_id,
+            (post.upvotes - post.downvotes) AS vote_count,
+            post.views,
+            post.created_at,
+            post.updated_at,
+            category.code AS category_code,
+            category.name AS category_name,
+            user.nickname AS author_nickname
+        FROM post
+                 LEFT JOIN category ON post.category_id = category.id
+                 LEFT JOIN user ON post.author_id = user.user_id
+        WHERE post.id = #{id}
+    </select>
+
 </mapper>


### PR DESCRIPTION
### 주요 변경 사항
- 커뮤니티 카테고리 및 게시글 목록 조회 기능 구현
  - CommunityController, CommunityService, CommunityMapper, Mapper XML 생성
  - 카테고리 전체 조회
  - 카테고리별 게시글 목록 조회
  - 카테고리별 게시글 개수 조회 기능 구현
  - CategoryResponseDTO: 카테고리 정보 응답 DTO
  - PostSummaryResponseDTO: 게시글 목록 응답용 DTO

- 게시글 상세 조회 기능 구현
  - 게시글 ID를 기반으로 단건 조회 API 추가
  - PostDetailResponseDTO를 통해 게시글 상세 데이터를 클라이언트에 전달
