### PR TITLE
커뮤니티 컨트롤러/서비스 구조 분리 및 조회 API 인증 예외 처리 추가

### DIFF
--- a/src/main/java/com/example/mockvoting/config/SecurityConfig.java
+++ b/src/main/java/com/example/mockvoting/config/SecurityConfig.java
@@ -43,6 +43,8 @@ public class SecurityConfig {
                 .authorizeHttpRequests(auth -> auth
                         .requestMatchers(HttpMethod.OPTIONS, "/**").permitAll() // Allow all OPTIONS requests
                         .requestMatchers("/api/users/oauth2/**").permitAll()
+                        .requestMatchers("/api/community/categories/**").permitAll()
+                        .requestMatchers(HttpMethod.GET, "/api/community/posts/**").permitAll()
                         .requestMatchers("/api/admin/**").hasRole("ADMIN")
                         .requestMatchers("/api/**").authenticated()
                         .anyRequest().permitAll()

--- a/src/main/java/com/example/mockvoting/domain/community/controller/CategoryController.java
+++ b/src/main/java/com/example/mockvoting/domain/community/controller/CategoryController.java
@@ -1,9 +1,8 @@
 package com.example.mockvoting.domain.community.controller;
 
 import com.example.mockvoting.domain.community.dto.CategoryResponseDTO;
-import com.example.mockvoting.domain.community.dto.PostDetailResponseDTO;
 import com.example.mockvoting.domain.community.dto.PostSummaryResponseDTO;
-import com.example.mockvoting.domain.community.service.CommunityService;
+import com.example.mockvoting.domain.community.service.CategoryService;
 import com.example.mockvoting.response.ApiResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -19,20 +18,20 @@ import java.util.List;
 
 @Slf4j
 @RestController
-@RequestMapping("/api/community")
+@RequestMapping("/api/community/categories")
 @RequiredArgsConstructor
-public class CommunityController {
-    private final CommunityService communityService;
+public class CategoryController {
+    private final CategoryService categoryService;
 
     /**
      *  게시글 카테고리 전체 조회
      */
-    @GetMapping("/categories")
+    @GetMapping
     public ResponseEntity<ApiResponse<List<CategoryResponseDTO>>> getAllCategories() {
         log.info("카테고리 전체 조회 요청");
 
         try {
-            List<CategoryResponseDTO> categories = communityService.getAllCategories();
+            List<CategoryResponseDTO> categories = categoryService.getAllCategories();
             log.info("카테고리 전체 조회 성공");
             return ResponseEntity.ok(ApiResponse.success("카테고리 전체 조회 성공", categories));
         } catch (Exception e) {
@@ -45,12 +44,12 @@ public class CommunityController {
     /**
      *  카테고리별 게시글 조회
      */
-    @GetMapping("/categories/{categoryCode}/posts")
+    @GetMapping("/{categoryCode}/posts")
     public ResponseEntity<ApiResponse<Page<PostSummaryResponseDTO>>> getPostsByCategory(@PathVariable String categoryCode, Pageable pageable) {
         log.info("카테고리 [{}]에 해당하는 게시글 목록 조회 요청", categoryCode);
 
         try {
-            Page<PostSummaryResponseDTO> posts = communityService.getPostsByCategory(categoryCode, pageable);
+            Page<PostSummaryResponseDTO> posts = categoryService.getPostsByCategory(categoryCode, pageable);
             log.info("카테고리 [{}] 게시글 목록 조회 성공", categoryCode);
             return ResponseEntity.ok(ApiResponse.success("게시글 목록 조회 성공", posts));
         } catch (Exception e) {
@@ -59,23 +58,4 @@ public class CommunityController {
                     .body(ApiResponse.error("게시글 목록 조회 실패"));
         }
     }
-
-    /**
-     *  게시글 상세 조회
-     */
-    @GetMapping("/posts/{id}")
-    public ResponseEntity<ApiResponse<PostDetailResponseDTO>> getPostDetail(@PathVariable Integer id) {
-        log.info("게시글 [{}] 상세 조회 요청", id);
-
-        try {
-            PostDetailResponseDTO post = communityService.getPostDetail(id);
-            log.info("게시글 [{}] 상세 조회 성공", id);
-            return ResponseEntity.ok(ApiResponse.success("게시글 상세 조회 성공", post));
-        } catch (Exception e) {
-            log.error("게시글 [{}] 상세 조회 중 오류 발생", id, e);
-            return ResponseEntity.internalServerError()
-                    .body(ApiResponse.error("게시글 상세 조회 실패"));
-        }
-    }
-
 }

--- a/src/main/java/com/example/mockvoting/domain/community/controller/PostController.java
+++ b/src/main/java/com/example/mockvoting/domain/community/controller/PostController.java
@@ -1,0 +1,38 @@
+package com.example.mockvoting.domain.community.controller;
+
+import com.example.mockvoting.domain.community.dto.PostDetailResponseDTO;
+import com.example.mockvoting.domain.community.service.PostService;
+import com.example.mockvoting.response.ApiResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Slf4j
+@RestController
+@RequestMapping("/api/community/posts")
+@RequiredArgsConstructor
+public class PostController {
+    private final PostService postService;
+
+    /**
+     *  게시글 상세 조회
+     */
+    @GetMapping("/{id}")
+    public ResponseEntity<ApiResponse<PostDetailResponseDTO>> getPostDetail(@PathVariable Integer id) {
+        log.info("게시글 [{}] 상세 조회 요청", id);
+
+        try {
+            PostDetailResponseDTO post = postService.getPostDetail(id);
+            log.info("게시글 [{}] 상세 조회 성공", id);
+            return ResponseEntity.ok(ApiResponse.success("게시글 상세 조회 성공", post));
+        } catch (Exception e) {
+            log.error("게시글 [{}] 상세 조회 중 오류 발생", id, e);
+            return ResponseEntity.internalServerError()
+                    .body(ApiResponse.error("게시글 상세 조회 실패"));
+        }
+    }
+}

--- a/src/main/java/com/example/mockvoting/domain/community/mapper/CategoryMapper.java
+++ b/src/main/java/com/example/mockvoting/domain/community/mapper/CategoryMapper.java
@@ -1,7 +1,6 @@
 package com.example.mockvoting.domain.community.mapper;
 
 import com.example.mockvoting.domain.community.dto.CategoryResponseDTO;
-import com.example.mockvoting.domain.community.dto.PostDetailResponseDTO;
 import com.example.mockvoting.domain.community.dto.PostSummaryResponseDTO;
 import org.apache.ibatis.annotations.Mapper;
 import org.apache.ibatis.annotations.Param;
@@ -9,7 +8,7 @@ import org.apache.ibatis.annotations.Param;
 import java.util.List;
 
 @Mapper
-public interface CommunityMapper {
+public interface CategoryMapper {
     // 게시글 카테고리 전체 조회
     List<CategoryResponseDTO> selectAllCategories();
 
@@ -21,6 +20,4 @@ public interface CommunityMapper {
     // 카테고리별 게시글 개수 조회
     int selectPostCountByCategory(@Param("categoryCode") String categoryCode);
 
-    // 게시글 상세 조회
-    PostDetailResponseDTO selectPostDetailById(@Param("id") Integer id);
 }

--- a/src/main/java/com/example/mockvoting/domain/community/mapper/PostMapper.java
+++ b/src/main/java/com/example/mockvoting/domain/community/mapper/PostMapper.java
@@ -1,0 +1,11 @@
+package com.example.mockvoting.domain.community.mapper;
+
+import com.example.mockvoting.domain.community.dto.PostDetailResponseDTO;
+import org.apache.ibatis.annotations.Mapper;
+import org.apache.ibatis.annotations.Param;
+
+@Mapper
+public interface PostMapper {
+    // 게시글 상세 조회
+    PostDetailResponseDTO selectPostDetailById(@Param("id") Integer id);
+}

--- a/src/main/java/com/example/mockvoting/domain/community/service/CategoryService.java
+++ b/src/main/java/com/example/mockvoting/domain/community/service/CategoryService.java
@@ -1,11 +1,9 @@
 package com.example.mockvoting.domain.community.service;
 
 import com.example.mockvoting.domain.community.dto.CategoryResponseDTO;
-import com.example.mockvoting.domain.community.dto.PostDetailResponseDTO;
 import com.example.mockvoting.domain.community.dto.PostSummaryResponseDTO;
-import com.example.mockvoting.domain.community.mapper.CommunityMapper;
+import com.example.mockvoting.domain.community.mapper.CategoryMapper;
 import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.Pageable;
@@ -13,17 +11,16 @@ import org.springframework.stereotype.Service;
 
 import java.util.List;
 
-@Slf4j
 @Service
 @RequiredArgsConstructor
-public class CommunityService {
-    private final CommunityMapper communityMapper;
+public class CategoryService {
+    private final CategoryMapper categoryMapper;
 
     /**
      *  게시글 카테고리 전체 조회
      */
     public List<CategoryResponseDTO> getAllCategories() {
-        return communityMapper.selectAllCategories();
+        return categoryMapper.selectAllCategories();
     }
 
     /**
@@ -33,16 +30,9 @@ public class CommunityService {
         int offset = (int) pageable.getOffset();
         int limit = (int) pageable.getPageSize();
 
-        List<PostSummaryResponseDTO> posts = communityMapper.selectPostsByCategory(categoryCode, offset, limit);
-        int total = communityMapper.selectPostCountByCategory(categoryCode);
+        List<PostSummaryResponseDTO> posts = categoryMapper.selectPostsByCategory(categoryCode, offset, limit);
+        int total = categoryMapper.selectPostCountByCategory(categoryCode);
 
         return new PageImpl<>(posts, pageable, total);
-    }
-
-    /**
-     *  게시글 상세 조회
-     */
-    public PostDetailResponseDTO getPostDetail(Integer id) {
-        return communityMapper.selectPostDetailById(id);
     }
 }

--- a/src/main/java/com/example/mockvoting/domain/community/service/PostService.java
+++ b/src/main/java/com/example/mockvoting/domain/community/service/PostService.java
@@ -1,0 +1,19 @@
+package com.example.mockvoting.domain.community.service;
+
+import com.example.mockvoting.domain.community.dto.PostDetailResponseDTO;
+import com.example.mockvoting.domain.community.mapper.PostMapper;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class PostService {
+    private final PostMapper postMapper;
+
+    /**
+     *  게시글 상세 조회
+     */
+    public PostDetailResponseDTO getPostDetail(Integer id) {
+        return postMapper.selectPostDetailById(id);
+    }
+}

--- a/src/main/java/com/example/mockvoting/security/JwtAuthorizationFilter.java
+++ b/src/main/java/com/example/mockvoting/security/JwtAuthorizationFilter.java
@@ -51,7 +51,11 @@ public class JwtAuthorizationFilter extends OncePerRequestFilter {
 
         // 인증이 필요 없는 경로는 바로 통과 (예: 구글 로그인만 제외)
         String path = request.getServletPath();
-        if (path.startsWith("/api/users/oauth2/")) {
+        String method = request.getMethod();
+        if (path.startsWith("/api/users/oauth2/")||
+                path.startsWith("/api/community/categories")||
+                (path.startsWith("/api/community/posts") && method.equals("GET"))
+        ) {
             filterChain.doFilter(request, response);
             return;
         }

--- a/src/main/resources/mapper/CategoryMapper.xml
+++ b/src/main/resources/mapper/CategoryMapper.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="com.example.mockvoting.domain.community.mapper.CommunityMapper">
+<mapper namespace="com.example.mockvoting.domain.community.mapper.CategoryMapper">
+
     <!-- 게시글 카테고리 전체 조회 -->
     <select id="selectAllCategories" resultType="com.example.mockvoting.domain.community.dto.CategoryResponseDTO">
         SELECT
@@ -32,7 +33,7 @@
         WHERE category.code = #{categoryCode}
           AND post.is_deleted = 0
         ORDER BY post.created_at DESC
-        LIMIT #{limit} OFFSET #{offset}
+            LIMIT #{limit} OFFSET #{offset}
     </select>
 
     <!-- 카테고리별 게시글 개수 조회 -->
@@ -42,27 +43,6 @@
                  JOIN category ON post.category_id = category.id
         WHERE category.code = #{categoryCode}
           AND post.is_deleted = 0
-    </select>
-
-    <!-- 게시글 상세 조회 -->
-    <select id="selectPostDetailById" resultType="com.example.mockvoting.domain.community.dto.PostDetailResponseDTO">
-        SELECT
-            post.id,
-            post.category_id,
-            post.title,
-            post.content,
-            post.author_id,
-            (post.upvotes - post.downvotes) AS vote_count,
-            post.views,
-            post.created_at,
-            post.updated_at,
-            category.code AS category_code,
-            category.name AS category_name,
-            user.nickname AS author_nickname
-        FROM post
-                 LEFT JOIN category ON post.category_id = category.id
-                 LEFT JOIN user ON post.author_id = user.user_id
-        WHERE post.id = #{id}
     </select>
 
 </mapper>

--- a/src/main/resources/mapper/PostMapper.xml
+++ b/src/main/resources/mapper/PostMapper.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+<mapper namespace="com.example.mockvoting.domain.community.mapper.PostMapper">
+
+    <!-- 게시글 상세 조회 -->
+    <select id="selectPostDetailById" resultType="com.example.mockvoting.domain.community.dto.PostDetailResponseDTO">
+        SELECT
+            post.id,
+            post.category_id,
+            post.title,
+            post.content,
+            post.author_id,
+            (post.upvotes - post.downvotes) AS vote_count,
+            post.views,
+            post.created_at,
+            post.updated_at,
+            category.code AS category_code,
+            category.name AS category_name,
+            user.nickname AS author_nickname
+        FROM post
+                 LEFT JOIN category ON post.category_id = category.id
+                 LEFT JOIN user ON post.author_id = user.user_id
+        WHERE post.id = #{id}
+    </select>
+
+</mapper>


### PR DESCRIPTION
### 주요 변경 사항
- 커뮤니티 기능 구조 개선
  - 기존 CommunityController를 역할에 따라 CategoryController와 PostController로 분리
  - Service 및 Mapper 계층도 각각 CategoryService, PostService 등으로 나누어 책임 명확화
  - 기능 단위의 명확한 패키지 구조로 유지보수성과 가독성 향상

- 보안 설정 개선
  - 비로그인 사용자도 커뮤니티 카테고리 및 게시글 조회가 가능하도록 인증 예외 경로 추가
  - SecurityConfig 및 JwtAuthorizationFilter에 /api/community/categories, /api/community/posts 경로 등록

### 변경 배경
- 커뮤니티 기능 확장에 대비하여 컨트롤러 및 서비스 계층을 역할 기반으로 구조화
- 커뮤니티 게시글을 로그인 없이도 열람 가능하게 함으로써 접근성 개선

### 테스트 방법
1. /api/community/categories, /api/community/posts GET 요청이 로그인 없이도 정상 동작하는지 확인
2. 전체 기능이 기존과 동일하게 동작하는지 회귀 테스트