### PR TITLE
커뮤니티 게시글 등록 기능 구현 및 구조 리팩터링

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -156,6 +156,13 @@
 			<version>2.44.0</version>
 		</dependency>
 
+		<!-- MapStruct core -->
+		<dependency>
+			<groupId>org.mapstruct</groupId>
+			<artifactId>mapstruct</artifactId>
+			<version>1.5.5.Final</version>
+		</dependency>
+
 	</dependencies>
 
 	<build>
@@ -186,6 +193,11 @@
 							<groupId>org.projectlombok</groupId>
 							<artifactId>lombok</artifactId>
 							<version>${lombok.version}</version>
+						</path>
+						<path>
+							<groupId>org.mapstruct</groupId>
+							<artifactId>mapstruct-processor</artifactId>
+							<version>1.5.5.Final</version>
 						</path>
 						<!-- 다른 어노테이션 프로세서가 있다면 여기에 추가 -->
 					</annotationProcessorPaths>

--- a/src/main/java/com/example/mockvoting/domain/community/controller/CategoryController.java
+++ b/src/main/java/com/example/mockvoting/domain/community/controller/CategoryController.java
@@ -1,16 +1,12 @@
 package com.example.mockvoting.domain.community.controller;
 
 import com.example.mockvoting.domain.community.dto.CategoryResponseDTO;
-import com.example.mockvoting.domain.community.dto.PostSummaryResponseDTO;
 import com.example.mockvoting.domain.community.service.CategoryService;
 import com.example.mockvoting.response.ApiResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.Pageable;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -38,24 +34,6 @@ public class CategoryController {
             log.error("카테고리 전체 조회 중 오류 발생", e);
             return ResponseEntity.internalServerError()
                     .body(ApiResponse.error("카테고리 전체 조회 실패"));
-        }
-    }
-
-    /**
-     *  카테고리별 게시글 조회
-     */
-    @GetMapping("/{categoryCode}/posts")
-    public ResponseEntity<ApiResponse<Page<PostSummaryResponseDTO>>> getPostsByCategory(@PathVariable String categoryCode, Pageable pageable) {
-        log.info("카테고리 [{}]에 해당하는 게시글 목록 조회 요청", categoryCode);
-
-        try {
-            Page<PostSummaryResponseDTO> posts = categoryService.getPostsByCategory(categoryCode, pageable);
-            log.info("카테고리 [{}] 게시글 목록 조회 성공", categoryCode);
-            return ResponseEntity.ok(ApiResponse.success("게시글 목록 조회 성공", posts));
-        } catch (Exception e) {
-            log.error("카테고리 [{}] 게시글 목록 조회 중 오류 발생", categoryCode, e);
-            return ResponseEntity.internalServerError()
-                    .body(ApiResponse.error("게시글 목록 조회 실패"));
         }
     }
 }

--- a/src/main/java/com/example/mockvoting/domain/community/controller/PostController.java
+++ b/src/main/java/com/example/mockvoting/domain/community/controller/PostController.java
@@ -1,15 +1,16 @@
 package com.example.mockvoting.domain.community.controller;
 
+import com.example.mockvoting.domain.community.dto.PostCreateRequestDTO;
 import com.example.mockvoting.domain.community.dto.PostDetailResponseDTO;
+import com.example.mockvoting.domain.community.dto.PostSummaryResponseDTO;
 import com.example.mockvoting.domain.community.service.PostService;
 import com.example.mockvoting.response.ApiResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @Slf4j
 @RestController
@@ -27,12 +28,48 @@ public class PostController {
 
         try {
             PostDetailResponseDTO post = postService.getPostDetail(id);
-            log.info("게시글 [{}] 상세 조회 성공", id);
+            log.info("게시글 [{}] 상세 조회 요청 처리 성공", id);
             return ResponseEntity.ok(ApiResponse.success("게시글 상세 조회 성공", post));
         } catch (Exception e) {
-            log.error("게시글 [{}] 상세 조회 중 오류 발생", id, e);
+            log.error("게시글 [{}] 상세 조회 요청 처리 실패", id, e);
             return ResponseEntity.internalServerError()
                     .body(ApiResponse.error("게시글 상세 조회 실패"));
         }
     }
+
+    /**
+     *  카테고리별 게시글 조회
+     */
+    @GetMapping("/category/{categoryCode}")
+    public ResponseEntity<ApiResponse<Page<PostSummaryResponseDTO>>> getPostsByCategory(@PathVariable String categoryCode, Pageable pageable) {
+        log.info("카테고리 [{}]에 해당하는 게시글 목록 조회 요청", categoryCode);
+
+        try {
+            Page<PostSummaryResponseDTO> posts = postService.getPostsByCategory(categoryCode, pageable);
+            log.info("카테고리 [{}] 게시글 목록 조회 요청 처리 성공", categoryCode);
+            return ResponseEntity.ok(ApiResponse.success("게시글 목록 조회 성공", posts));
+        } catch (Exception e) {
+            log.error("카테고리 [{}] 게시글 목록 조회 요청 처리 실패", categoryCode, e);
+            return ResponseEntity.internalServerError()
+                    .body(ApiResponse.error("게시글 목록 조회 실패"));
+        }
+    }
+
+    /**
+     *  게시글 등록
+     */
+    @PostMapping
+    public ResponseEntity<ApiResponse<Long>> createPost(@RequestBody PostCreateRequestDTO dto) {
+        log.info("게시글 등록 요청: {}", dto.getTitle());
+
+        try {
+            Long postId = postService.save(dto);
+            log.info("게시글 등록 요청 처리 성공: id={}", postId);
+            return ResponseEntity.ok(ApiResponse.success("게시글 등록 성공", postId));
+        } catch (Exception e) {
+            log.error("게시글 등록 요청 처리 실패", e);
+            return ResponseEntity.internalServerError().body(ApiResponse.error("게시글 등록 실패"));
+        }
+    }
+
 }

--- a/src/main/java/com/example/mockvoting/domain/community/dto/PostCreateRequestDTO.java
+++ b/src/main/java/com/example/mockvoting/domain/community/dto/PostCreateRequestDTO.java
@@ -1,0 +1,19 @@
+package com.example.mockvoting.domain.community.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class PostCreateRequestDTO {
+    private Long id;
+    private Long categoryId;
+    private String title;
+    private String content;
+    private String authorId;
+    private String thumbnailUrl;
+}

--- a/src/main/java/com/example/mockvoting/domain/community/entity/Post.java
+++ b/src/main/java/com/example/mockvoting/domain/community/entity/Post.java
@@ -1,0 +1,65 @@
+package com.example.mockvoting.domain.community.entity;
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name="post")
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class Post {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "category_id", nullable = false)
+    private Long categoryId;
+
+    @Column(nullable = false, length = 100)
+    private String title;
+
+    @Column(nullable = false, columnDefinition = "TEXT")
+    private String content;
+
+    @Column(name = "author_id", nullable = false, length = 50)
+    private String authorId;
+
+    @Column(name = "thumbnail_url", length = 255)
+    private String thumbnailUrl;
+
+    @Column(nullable = false)
+    private int upvotes;
+
+    @Column(nullable = false)
+    private int downvotes;
+
+    @Column(nullable = false)
+    private int views;
+
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+    @Column(name = "updated_at")
+    private LocalDateTime updatedAt;
+
+    @Column(name = "is_deleted", nullable = false)
+    private boolean isDeleted;
+
+    @PrePersist
+    protected void onCreate() {
+        this.createdAt = LocalDateTime.now();
+    }
+
+    @PreUpdate
+    protected void onUpdate() {
+        this.updatedAt = LocalDateTime.now();
+    }
+}

--- a/src/main/java/com/example/mockvoting/domain/community/mapper/CategoryMapper.java
+++ b/src/main/java/com/example/mockvoting/domain/community/mapper/CategoryMapper.java
@@ -1,7 +1,6 @@
 package com.example.mockvoting.domain.community.mapper;
 
 import com.example.mockvoting.domain.community.dto.CategoryResponseDTO;
-import com.example.mockvoting.domain.community.dto.PostSummaryResponseDTO;
 import org.apache.ibatis.annotations.Mapper;
 import org.apache.ibatis.annotations.Param;
 
@@ -12,12 +11,6 @@ public interface CategoryMapper {
     // 게시글 카테고리 전체 조회
     List<CategoryResponseDTO> selectAllCategories();
 
-    // 카테고리별 게시글 조회
-    List<PostSummaryResponseDTO> selectPostsByCategory(@Param("categoryCode") String categoryCode,
-                                                       @Param("offset") int offset,
-                                                       @Param("limit") int limit);
-
     // 카테고리별 게시글 개수 조회
     int selectPostCountByCategory(@Param("categoryCode") String categoryCode);
-
 }

--- a/src/main/java/com/example/mockvoting/domain/community/mapper/PostMapper.java
+++ b/src/main/java/com/example/mockvoting/domain/community/mapper/PostMapper.java
@@ -1,11 +1,19 @@
 package com.example.mockvoting.domain.community.mapper;
 
 import com.example.mockvoting.domain.community.dto.PostDetailResponseDTO;
+import com.example.mockvoting.domain.community.dto.PostSummaryResponseDTO;
 import org.apache.ibatis.annotations.Mapper;
 import org.apache.ibatis.annotations.Param;
+
+import java.util.List;
 
 @Mapper
 public interface PostMapper {
     // 게시글 상세 조회
     PostDetailResponseDTO selectPostDetailById(@Param("id") Integer id);
+
+    // 카테고리별 게시글 조회
+    List<PostSummaryResponseDTO> selectPostsByCategory(@Param("categoryCode") String categoryCode,
+                                                       @Param("offset") int offset,
+                                                       @Param("limit") int limit);
 }

--- a/src/main/java/com/example/mockvoting/domain/community/mapper/converter/PostDtoMapper.java
+++ b/src/main/java/com/example/mockvoting/domain/community/mapper/converter/PostDtoMapper.java
@@ -1,0 +1,12 @@
+package com.example.mockvoting.domain.community.mapper.converter;
+
+import com.example.mockvoting.domain.community.dto.PostCreateRequestDTO;
+import com.example.mockvoting.domain.community.entity.Post;
+import org.mapstruct.Mapper;
+
+@Mapper(componentModel = "spring")
+public interface PostDtoMapper {
+
+    Post toEntity(PostCreateRequestDTO postCreateRequestDTO);
+
+}

--- a/src/main/java/com/example/mockvoting/domain/community/repository/PostRepository.java
+++ b/src/main/java/com/example/mockvoting/domain/community/repository/PostRepository.java
@@ -1,0 +1,8 @@
+package com.example.mockvoting.domain.community.repository;
+
+import com.example.mockvoting.domain.community.entity.Post;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface PostRepository extends JpaRepository<Post, Long> {
+
+}

--- a/src/main/java/com/example/mockvoting/domain/community/service/CategoryService.java
+++ b/src/main/java/com/example/mockvoting/domain/community/service/CategoryService.java
@@ -1,12 +1,8 @@
 package com.example.mockvoting.domain.community.service;
 
 import com.example.mockvoting.domain.community.dto.CategoryResponseDTO;
-import com.example.mockvoting.domain.community.dto.PostSummaryResponseDTO;
 import com.example.mockvoting.domain.community.mapper.CategoryMapper;
 import lombok.RequiredArgsConstructor;
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.PageImpl;
-import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
@@ -23,16 +19,4 @@ public class CategoryService {
         return categoryMapper.selectAllCategories();
     }
 
-    /**
-     *  카테고리별 게시글 조회
-     */
-    public Page<PostSummaryResponseDTO> getPostsByCategory(String categoryCode, Pageable pageable) {
-        int offset = (int) pageable.getOffset();
-        int limit = (int) pageable.getPageSize();
-
-        List<PostSummaryResponseDTO> posts = categoryMapper.selectPostsByCategory(categoryCode, offset, limit);
-        int total = categoryMapper.selectPostCountByCategory(categoryCode);
-
-        return new PageImpl<>(posts, pageable, total);
-    }
 }

--- a/src/main/java/com/example/mockvoting/domain/community/service/PostService.java
+++ b/src/main/java/com/example/mockvoting/domain/community/service/PostService.java
@@ -1,19 +1,57 @@
 package com.example.mockvoting.domain.community.service;
 
+import com.example.mockvoting.domain.community.dto.PostCreateRequestDTO;
 import com.example.mockvoting.domain.community.dto.PostDetailResponseDTO;
+import com.example.mockvoting.domain.community.dto.PostSummaryResponseDTO;
+import com.example.mockvoting.domain.community.entity.Post;
+import com.example.mockvoting.domain.community.mapper.CategoryMapper;
 import com.example.mockvoting.domain.community.mapper.PostMapper;
+import com.example.mockvoting.domain.community.mapper.converter.PostDtoMapper;
+import com.example.mockvoting.domain.community.repository.PostRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
 
 @Service
 @RequiredArgsConstructor
 public class PostService {
     private final PostMapper postMapper;
+    private final CategoryMapper categoryMapper;
+    private final PostRepository postRepository;
+    private final PostDtoMapper postDtoMapper;
 
     /**
      *  게시글 상세 조회
      */
     public PostDetailResponseDTO getPostDetail(Integer id) {
         return postMapper.selectPostDetailById(id);
+    }
+
+    /**
+     *  카테고리별 게시글 조회
+     */
+    @Transactional(readOnly = true)
+    public Page<PostSummaryResponseDTO> getPostsByCategory(String categoryCode, Pageable pageable) {
+        int offset = (int) pageable.getOffset();
+        int limit = (int) pageable.getPageSize();
+
+        List<PostSummaryResponseDTO> posts = postMapper.selectPostsByCategory(categoryCode, offset, limit);
+        int total = categoryMapper.selectPostCountByCategory(categoryCode);
+
+        return new PageImpl<>(posts, pageable, total);
+    }
+
+    /**
+     *  게시글 등록
+     */
+    @Transactional
+    public Long save(PostCreateRequestDTO dto) {
+        Post post = postDtoMapper.toEntity(dto);
+        return postRepository.save(post).getId();
     }
 }

--- a/src/main/java/com/example/mockvoting/domain/gcs/controller/FileController.java
+++ b/src/main/java/com/example/mockvoting/domain/gcs/controller/FileController.java
@@ -1,0 +1,36 @@
+package com.example.mockvoting.domain.gcs.controller;
+
+import com.example.mockvoting.domain.gcs.service.GcsService;
+import com.example.mockvoting.response.ApiResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.multipart.MultipartFile;
+
+@Slf4j
+@RestController
+@RequestMapping("/api/files")
+@RequiredArgsConstructor
+public class FileController {
+    private final GcsService gcsService;
+
+    @PostMapping("/upload")
+    public ResponseEntity<ApiResponse<String>> upload(@RequestParam String type,
+                                                        @RequestParam MultipartFile file) {
+        log.info("파일 업로드 요청: type={}, filename={}", type, file.getOriginalFilename());
+
+        try {
+            String url = gcsService.upload(type, file);
+            log.info("파일 업로드 요청 처리 성공: type={}, url={}", type, url);
+            return ResponseEntity.ok(ApiResponse.success("파일 업로드 성공", url));
+        } catch (Exception e) {
+            log.error("파일 업로드 요청 처리 실패: type={}, filename={}", type, file.getOriginalFilename(), e);
+            return ResponseEntity.internalServerError()
+                    .body(ApiResponse.error("파일 업로드 실패"));
+        }
+    }
+}

--- a/src/main/resources/mapper/CategoryMapper.xml
+++ b/src/main/resources/mapper/CategoryMapper.xml
@@ -14,28 +14,6 @@
         ORDER BY sort_order ASC
     </select>
 
-    <!-- 카테고리별 게시글 조회 -->
-    <select id="selectPostsByCategory" resultType="com.example.mockvoting.domain.community.dto.PostSummaryResponseDTO">
-        SELECT
-            post.id,
-            post.category_id,
-            post.title,
-            post.author_id,
-            post.thumbnail_url,
-            (post.upvotes - post.downvotes) AS voteCount,
-            post.views,
-            post.created_at,
-            category.name AS categoryName,
-            user.nickname AS authorNickname
-        FROM post
-                 JOIN category ON post.category_id = category.id
-                 JOIN user ON post.author_id = user.user_id
-        WHERE category.code = #{categoryCode}
-          AND post.is_deleted = 0
-        ORDER BY post.created_at DESC
-            LIMIT #{limit} OFFSET #{offset}
-    </select>
-
     <!-- 카테고리별 게시글 개수 조회 -->
     <select id="selectPostCountByCategory" resultType="int">
         SELECT COUNT(*)

--- a/src/main/resources/mapper/PostMapper.xml
+++ b/src/main/resources/mapper/PostMapper.xml
@@ -23,4 +23,25 @@
         WHERE post.id = #{id}
     </select>
 
+    <!-- 카테고리별 게시글 조회 -->
+    <select id="selectPostsByCategory" resultType="com.example.mockvoting.domain.community.dto.PostSummaryResponseDTO">
+        SELECT
+            post.id,
+            post.category_id,
+            post.title,
+            post.author_id,
+            post.thumbnail_url,
+            (post.upvotes - post.downvotes) AS voteCount,
+            post.views,
+            post.created_at,
+            category.name AS categoryName,
+            user.nickname AS authorNickname
+        FROM post
+                 JOIN category ON post.category_id = category.id
+                 JOIN user ON post.author_id = user.user_id
+        WHERE category.code = #{categoryCode}
+          AND post.is_deleted = 0
+        ORDER BY post.created_at DESC
+            LIMIT #{limit} OFFSET #{offset}
+    </select>
 </mapper>


### PR DESCRIPTION
## 커뮤니티 게시글 등록 기능 구현 및 구조 리팩터링

### 주요 변경 사항
- **MapStruct 도입**
  - JPA Entity-DTO 매핑 자동화를 위해 `mapstruct` 디펜던시 추가

- **파일 업로드 기능 구현**
  - 파일 업로드 전용 `FileController` 클래스 신규 생성
  - `GcsService` 수정: 업로드 완료 시 GCS 파일 URL 반환하도록 로직 변경

- **커뮤니티 구조 리팩터링**
  - 기존 `CategoryController`, `CategoryService`, `CategoryMapper`에서 게시글 조회 관련 메서드 제거
  - 게시글 조회 책임을 `PostController`, `PostService`, `PostMapper`로 이전하여 역할 분리 명확화

- **게시글 도메인 및 등록 기능 구현**
  - `Post` Entity 클래스 생성
  - `PostDtoMapper` 인터페이스(MapStruct 기반) 생성
  - `PostRepository` 인터페이스 생성하여 JPA 기반 CRUD 지원
  - `PostCreateRequestDTO` 생성
  - `PostController`에 게시글 등록 API 추가

### 변경 배경
- 도메인 책임을 분리하여 구조의 명확성과 유지보수성 향상
- 향후 게시글 기능 확장(JPA 기반 CRUD, 검색 등)을 고려한 설계
- 업로드 후 URL 활용 가능성을 위해 업로드 결과 값을 명확히 반환
- 커뮤니티 게시글 등록 기능 구현을 위한 기본 구조 마련

### 테스트 방법
1. `/api/files/upload` API를 통해 파일 업로드 시 URL이 정상 반환되는지 확인  
2. `/api/community/posts` POST 요청으로 게시글 등록이 정상 동작하는지 확인  
3. 게시글 조회 관련 로직이 Post 계층으로 잘 이전되었는지 확인  
4. 전체 커뮤니티 기능이 기존과 동일하게 동작하는지 회귀 테스트
