### PR TITLE
GCS 업로드 파일명 인코딩 및 게시글 썸네일 예외 처리

### DIFF
--- a/src/main/java/com/example/mockvoting/domain/community/service/PostService.java
+++ b/src/main/java/com/example/mockvoting/domain/community/service/PostService.java
@@ -52,6 +52,12 @@ public class PostService {
     @Transactional
     public Long save(PostCreateRequestDTO dto) {
         Post post = postDtoMapper.toEntity(dto);
+
+        // 썸네일이 없으면 기본 이미지 경로로 설정
+        if (post.getThumbnailUrl() == null || post.getThumbnailUrl().isBlank()) {
+            post.setThumbnailUrl("https://storage.googleapis.com/visionvote_uploads/post/images/default_thumnail.jpg");
+        }
+
         return postRepository.save(post).getId();
     }
 }

--- a/src/main/java/com/example/mockvoting/domain/gcs/service/GcsService.java
+++ b/src/main/java/com/example/mockvoting/domain/gcs/service/GcsService.java
@@ -38,8 +38,12 @@ public class GcsService {
 
     public String upload(String type, MultipartFile file) {
         try {
-            String fileName = UUID.randomUUID() + "_" + file.getOriginalFilename();
-            String fullPath = resolvePath(type, fileName);
+            String originalName = file.getOriginalFilename();
+            String uuid = UUID.randomUUID().toString();
+
+            String extension = originalName.substring(originalName.lastIndexOf('.'));
+            String safeFileName = uuid + extension;
+            String fullPath = resolvePath(type, safeFileName);
 
             BlobInfo blobInfo = BlobInfo.newBuilder(bucketName, fullPath)
                     .setContentType(file.getContentType())


### PR DESCRIPTION
## GCS 업로드 파일명 인코딩 및 게시글 썸네일 예외 처리

### 주요 변경 사항
- **GCS 업로드 시 파일명 처리 개선**
  - 한글 또는 공백이 포함된 파일 업로드 시 이미지가 엑박으로 표시되던 문제 해결
  - 파일명을 UUID + 확장자 형태로 생성하여 URL 인코딩 문제 방지 및 안정성 확보

- **게시글 썸네일 예외 처리**
  - 썸네일 URL이 null일 경우 기본 이미지 경로를 설정하여 오류 방지
  - 이미지 유무와 관계없이 게시글이 정상 등록되도록 처리

### 변경 배경
- 브라우저가 한글/공백이 포함된 GCS 이미지 URL을 인식하지 못해 엑박이 발생
- 게시글 데이터 등록 중 사진이 없는 경우 썸네일 URL null 오류 발생

### 테스트 방법
1. 한글/공백이 포함된 파일을 업로드하고 이미지가 정상 표시되는지 확인  
2. 기존 게시글 및 이미지 로직 회귀 테스트
