### PR TITLE
게시글 첨부파일 기능 구현 및 상세 조회 개선

### DIFF
--- a/src/main/java/com/example/mockvoting/domain/community/dto/PostAttachmentResponseDTO.java
+++ b/src/main/java/com/example/mockvoting/domain/community/dto/PostAttachmentResponseDTO.java
@@ -1,0 +1,17 @@
+package com.example.mockvoting.domain.community.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class PostAttachmentResponseDTO {
+    private String id;
+    private String name;
+    private String url;
+    private Long size;
+}

--- a/src/main/java/com/example/mockvoting/domain/community/dto/PostDetailResponseDTO.java
+++ b/src/main/java/com/example/mockvoting/domain/community/dto/PostDetailResponseDTO.java
@@ -6,6 +6,7 @@ import lombok.Data;
 import lombok.NoArgsConstructor;
 
 import java.time.LocalDateTime;
+import java.util.List;
 
 @Data
 @Builder
@@ -25,4 +26,5 @@ public class PostDetailResponseDTO {
     private String categoryCode;
     private String categoryName;
     private String authorNickname;
+    private List<PostAttachmentResponseDTO> attachments;
 }

--- a/src/main/java/com/example/mockvoting/domain/community/dto/PostDetailViewDTO.java
+++ b/src/main/java/com/example/mockvoting/domain/community/dto/PostDetailViewDTO.java
@@ -1,0 +1,10 @@
+package com.example.mockvoting.domain.community.dto;
+
+import lombok.*;
+
+@Value
+@Builder
+public class PostDetailViewDTO {    // PostController <- PostService 데이터 전달용 DTO
+    PostDetailResponseDTO post;
+    String newViewedPostIds;
+}

--- a/src/main/java/com/example/mockvoting/domain/community/entity/PostAttachment.java
+++ b/src/main/java/com/example/mockvoting/domain/community/entity/PostAttachment.java
@@ -1,0 +1,45 @@
+package com.example.mockvoting.domain.community.entity;
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "post_attachment")
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class PostAttachment {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "post_id", nullable = false)
+    private Long postId;
+
+    @Column(nullable = false, length = 50)
+    private String name;
+
+    @Column(nullable = false, length = 255)
+    private String url;
+
+    @Column(nullable = false)
+    private Long size;
+
+    @Column(name = "created_at", nullable = false)
+    private LocalDateTime createdAt;
+
+    @Column(name = "is_deleted", nullable = false)
+    private Boolean isDeleted = false;
+
+    @PrePersist
+    protected void onCreate() {
+        this.createdAt = LocalDateTime.now();
+    }
+}

--- a/src/main/java/com/example/mockvoting/domain/community/mapper/PostAttachmentMapper.java
+++ b/src/main/java/com/example/mockvoting/domain/community/mapper/PostAttachmentMapper.java
@@ -1,0 +1,13 @@
+package com.example.mockvoting.domain.community.mapper;
+
+import com.example.mockvoting.domain.community.dto.PostAttachmentResponseDTO;
+import org.apache.ibatis.annotations.Mapper;
+import org.apache.ibatis.annotations.Param;
+
+import java.util.List;
+
+@Mapper
+public interface PostAttachmentMapper {
+    // 게시글별 첨부파일 목록 조회
+    List<PostAttachmentResponseDTO> selectAttachmentsByPostId(@Param("postId") Integer postId);
+}

--- a/src/main/java/com/example/mockvoting/domain/community/mapper/PostMapper.java
+++ b/src/main/java/com/example/mockvoting/domain/community/mapper/PostMapper.java
@@ -16,4 +16,6 @@ public interface PostMapper {
     List<PostSummaryResponseDTO> selectPostsByCategory(@Param("categoryCode") String categoryCode,
                                                        @Param("offset") int offset,
                                                        @Param("limit") int limit);
+    // 게시글 조회수 업데이트
+    void updateViewCountById(@Param("id") Integer id);
 }

--- a/src/main/java/com/example/mockvoting/domain/community/repository/PostAttachmentRepository.java
+++ b/src/main/java/com/example/mockvoting/domain/community/repository/PostAttachmentRepository.java
@@ -1,0 +1,7 @@
+package com.example.mockvoting.domain.community.repository;
+
+import com.example.mockvoting.domain.community.entity.PostAttachment;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface PostAttachmentRepository extends JpaRepository<PostAttachment, Long> {
+}

--- a/src/main/java/com/example/mockvoting/domain/community/service/PostService.java
+++ b/src/main/java/com/example/mockvoting/domain/community/service/PostService.java
@@ -1,20 +1,25 @@
 package com.example.mockvoting.domain.community.service;
 
-import com.example.mockvoting.domain.community.dto.PostCreateRequestDTO;
-import com.example.mockvoting.domain.community.dto.PostDetailResponseDTO;
-import com.example.mockvoting.domain.community.dto.PostSummaryResponseDTO;
+import com.example.mockvoting.domain.community.dto.*;
 import com.example.mockvoting.domain.community.entity.Post;
+import com.example.mockvoting.domain.community.entity.PostAttachment;
 import com.example.mockvoting.domain.community.mapper.CategoryMapper;
+import com.example.mockvoting.domain.community.mapper.PostAttachmentMapper;
 import com.example.mockvoting.domain.community.mapper.PostMapper;
 import com.example.mockvoting.domain.community.mapper.converter.PostDtoMapper;
+import com.example.mockvoting.domain.community.repository.PostAttachmentRepository;
 import com.example.mockvoting.domain.community.repository.PostRepository;
+import com.example.mockvoting.domain.gcs.service.GcsService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
 
+import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 
 @Service
@@ -22,14 +27,43 @@ import java.util.List;
 public class PostService {
     private final PostMapper postMapper;
     private final CategoryMapper categoryMapper;
+    private final PostAttachmentMapper postAttachmentMapper;
     private final PostRepository postRepository;
+    private final PostAttachmentRepository postAttachmentRepository;
     private final PostDtoMapper postDtoMapper;
+    private final GcsService gcsService;
 
     /**
      *  게시글 상세 조회
      */
-    public PostDetailResponseDTO getPostDetail(Integer id) {
-        return postMapper.selectPostDetailById(id);
+    @Transactional
+    public PostDetailViewDTO getPostDetail(Integer id, String viewedPostIds) {
+        // 1) 조회 여부 판단 - 조회하는 게시글이 이전에 사용자가 조회한 게시글인가?
+        List<String> viewedList = viewedPostIds.isEmpty()
+                ? Collections.emptyList()
+                : Arrays.asList(viewedPostIds.split("-"));
+        boolean alreadyViewed = viewedList.contains(id.toString());
+
+        String updatedViewedPostIds = null;
+        if (!alreadyViewed) {
+            // 2) 조회수 증가
+            postMapper.updateViewCountById(id);
+            // 3) 쿠키에 담을 새 값 계산
+            updatedViewedPostIds = viewedPostIds.isEmpty()
+                    ? id.toString()
+                    : viewedPostIds + "-" + id;
+        }
+
+        // 게시글 조회
+        PostDetailResponseDTO detail = postMapper.selectPostDetailById(id);
+        // 첨부파일 조회
+        List<PostAttachmentResponseDTO> attachments = postAttachmentMapper.selectAttachmentsByPostId(id);
+        detail.setAttachments(attachments);
+
+        return PostDetailViewDTO.builder()
+                .post(detail)
+                .newViewedPostIds(updatedViewedPostIds)
+                .build();
     }
 
     /**
@@ -49,8 +83,23 @@ public class PostService {
     /**
      *  게시글 등록
      */
+//    @Transactional
+//    public Long save(PostCreateRequestDTO dto) {
+//        Post post = postDtoMapper.toEntity(dto);
+//
+//        // 썸네일이 없으면 기본 이미지 경로로 설정
+//        if (post.getThumbnailUrl() == null || post.getThumbnailUrl().isBlank()) {
+//            post.setThumbnailUrl("https://storage.googleapis.com/visionvote_uploads/post/images/default_thumnail.jpg");
+//        }
+//
+//        return postRepository.save(post).getId();
+//    }
+
+    /**
+     *  게시글 등록 (첨부파일 포함)
+     */
     @Transactional
-    public Long save(PostCreateRequestDTO dto) {
+    public Long save(PostCreateRequestDTO dto, List<MultipartFile> files) {
         Post post = postDtoMapper.toEntity(dto);
 
         // 썸네일이 없으면 기본 이미지 경로로 설정
@@ -58,6 +107,24 @@ public class PostService {
             post.setThumbnailUrl("https://storage.googleapis.com/visionvote_uploads/post/images/default_thumnail.jpg");
         }
 
-        return postRepository.save(post).getId();
+        Long id = postRepository.save(post).getId();
+
+        if (files != null && !files.isEmpty()) {
+            for (MultipartFile file : files) {
+                String url = gcsService.upload("post_attachments", file);
+
+                PostAttachment attachment = PostAttachment.builder()
+                        .postId(id)
+                        .name(file.getOriginalFilename())
+                        .url(url)
+                        .size(file.getSize())
+                        .isDeleted(false)
+                        .build();
+
+                postAttachmentRepository.save(attachment);
+            }
+        }
+
+        return id;
     }
 }

--- a/src/main/java/com/example/mockvoting/domain/gcs/service/GcsService.java
+++ b/src/main/java/com/example/mockvoting/domain/gcs/service/GcsService.java
@@ -45,9 +45,14 @@ public class GcsService {
             String safeFileName = uuid + extension;
             String fullPath = resolvePath(type, safeFileName);
 
-            BlobInfo blobInfo = BlobInfo.newBuilder(bucketName, fullPath)
-                    .setContentType(file.getContentType())
-                    .build();
+            BlobInfo.Builder blobBuilder = BlobInfo.newBuilder(bucketName, fullPath)
+                    .setContentType(file.getContentType());
+
+            if ("post_attachments".equals(type)) {
+                blobBuilder.setContentDisposition("attachment; filename=\"" + originalName + "\"");
+            }
+
+            BlobInfo blobInfo = blobBuilder.build();
 
             storage.create(blobInfo, file.getBytes());
             log.info("파일 업로드 성공: {}", fullPath);

--- a/src/main/resources/mapper/PostAttachmentMapper.xml
+++ b/src/main/resources/mapper/PostAttachmentMapper.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+<mapper namespace="com.example.mockvoting.domain.community.mapper.PostAttachmentMapper">
+    <select id="selectAttachmentsByPostId" resultType="com.example.mockvoting.domain.community.dto.PostAttachmentResponseDTO">
+        SELECT
+            id, name, url, size
+        FROM
+            post_attachment
+        WHERE
+            post_id = #{postId}
+        ORDER BY id
+    </select>
+</mapper>

--- a/src/main/resources/mapper/PostAttachmentMapper.xml
+++ b/src/main/resources/mapper/PostAttachmentMapper.xml
@@ -7,7 +7,7 @@
         FROM
             post_attachment
         WHERE
-            post_id = #{postId}
+            post_id = #{postId} AND is_deleted = FALSE
         ORDER BY id
     </select>
 </mapper>

--- a/src/main/resources/mapper/PostMapper.xml
+++ b/src/main/resources/mapper/PostMapper.xml
@@ -44,4 +44,11 @@
         ORDER BY post.created_at DESC
             LIMIT #{limit} OFFSET #{offset}
     </select>
+
+    <!-- 게시글 조회수 업데이트 -->
+    <update id="updateViewCountById">
+        UPDATE post
+        SET views = views + 1
+        WHERE id = #{id}
+    </update>
 </mapper>


### PR DESCRIPTION
## 게시글 첨부파일 기능 구현 및 상세 조회 개선

### 주요 변경 사항
- **첨부파일 업로드 처리**
  - GCS 업로드 시 `type`이 `post_attachments`인 경우 Content-Disposition을 `attachment`로 설정
  - 브라우저에서 첨부파일 다운로드가 바로 되도록 처리

- **첨부파일 저장/조회 기능 구현**
  - `PostAttachment` 엔티티 생성
  - `PostAttachmentMapper`(MyBatis 조회용) 및 `PostAttachmentRepository`(JPA 저장용) 추가
  - `PostAttachmentMapper.xml` 생성

- **게시글 상세 DTO 확장**
  - `PostDetailResponseDTO`에 `attachments` 필드 추가
  - 게시글 상세 조회 시 첨부파일 목록 함께 제공

- **조회수 처리 및 ViewDTO 도입**
  - `PostDetailViewDTO` 도입: 게시글 정보 + 조회한 게시글 ID 목록을 함께 반환
  - 쿠키 기반 중복 조회 방지를 위한 구조 설계

- **게시글 등록 시 첨부파일 저장 로직 추가**
  - 게시글 등록 시 첨부파일도 함께 저장되도록 컨트롤러 및 서비스 로직 개선

- **삭제된 첨부파일 필터링**
  - `PostAttachmentMapper.xml`의 `selectAttachmentsByPostId` 쿼리에 `is_deleted = FALSE` 조건 추가
  - 상세 조회 시 삭제된 첨부파일이 노출되지 않도록 처리

### 변경 배경
- 게시글에 첨부파일을 등록하고, 상세 페이지에서 이를 다운로드 가능한 형태로 제공하기 위함
- 기존에는 첨부파일이 포함되지 않았고, 조회수 중복 방지도 없었음
- 삭제된 첨부파일이 그대로 노출되는 문제를 방지하기 위해 조건 추가

### 테스트 방법
1. 게시글 등록 시 첨부파일이 함께 업로드되고 저장되는지 확인  
2. 게시글 상세 조회 시 첨부파일 목록이 함께 반환되는지 확인  
3. 첨부파일 클릭 시 브라우저에서 다운로드가 정상 동작하는지 확인  
4. 같은 게시글을 여러 번 조회해도 조회수가 중복 증가하지 않는지 확인  
5. 삭제된 첨부파일이 상세 조회 결과에서 제외되는지 확인
