### PR TITLE
 YouTube API 캐싱 처리 및 예외 대응 개선 및 WikipediaAPI 검색 사전 구현

### DIFF
--- a/src/main/java/com/example/mockvoting/domain/glossary/controller/GlossaryController.java
+++ b/src/main/java/com/example/mockvoting/domain/glossary/controller/GlossaryController.java
@@ -1,0 +1,32 @@
+package com.example.mockvoting.domain.glossary.controller;
+
+
+
+import com.example.mockvoting.domain.glossary.dto.GlossaryDTO;
+import com.example.mockvoting.domain.glossary.service.GlossaryService;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/glossary")
+@CrossOrigin(origins = "*")
+public class GlossaryController {
+
+    private final GlossaryService service;
+
+    public GlossaryController(GlossaryService service) {
+        this.service = service;
+    }
+
+    @GetMapping("/search")
+    public ResponseEntity<?> search(@RequestParam("q") String q) {
+        GlossaryDTO dto = service.search(q.trim());
+        if (dto != null) {
+            return ResponseEntity.ok(dto);
+        }
+        return ResponseEntity.status(404)
+                .body("용어를 찾을 수 없습니다: " + q);
+    }
+}

--- a/src/main/java/com/example/mockvoting/domain/glossary/dto/GlossaryDTO.java
+++ b/src/main/java/com/example/mockvoting/domain/glossary/dto/GlossaryDTO.java
@@ -1,0 +1,15 @@
+package com.example.mockvoting.domain.glossary.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class GlossaryDTO {
+    private String term;
+    private String definition;
+    private String source;   // "DB" or "Wikipedia"
+    private String pageUrl;  // 위키백과 링크 (optional)
+}

--- a/src/main/java/com/example/mockvoting/domain/glossary/entity/GlossaryTerm.java
+++ b/src/main/java/com/example/mockvoting/domain/glossary/entity/GlossaryTerm.java
@@ -1,0 +1,26 @@
+package com.example.mockvoting.domain.glossary.entity;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import lombok.*;
+
+@Entity
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class GlossaryTerm {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private String term;          // 용어
+    private String definition;    // 정의
+    private String source;        // 출처 (선택)
+
+    private String keywords;      // 키워드 (검색 필터용)
+}

--- a/src/main/java/com/example/mockvoting/domain/glossary/repository/GlossaryTermRepository.java
+++ b/src/main/java/com/example/mockvoting/domain/glossary/repository/GlossaryTermRepository.java
@@ -1,0 +1,10 @@
+package com.example.mockvoting.domain.glossary.repository;
+
+import com.example.mockvoting.domain.glossary.entity.GlossaryTerm;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface GlossaryTermRepository extends JpaRepository<GlossaryTerm, Long> {
+    List<GlossaryTerm> findByTermContainingIgnoreCase(String term);
+}

--- a/src/main/java/com/example/mockvoting/domain/glossary/service/GlossaryService.java
+++ b/src/main/java/com/example/mockvoting/domain/glossary/service/GlossaryService.java
@@ -1,0 +1,108 @@
+package com.example.mockvoting.domain.glossary.service;
+
+import com.example.mockvoting.domain.glossary.dto.GlossaryDTO;
+import com.example.mockvoting.domain.glossary.entity.GlossaryTerm;
+import com.example.mockvoting.domain.glossary.repository.GlossaryTermRepository;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.springframework.stereotype.Service;
+
+import java.net.URI;
+import java.net.URLEncoder;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.nio.charset.StandardCharsets;
+import java.util.Optional;
+
+@Service
+public class GlossaryService {
+
+    private final GlossaryTermRepository repo;
+    private final ObjectMapper mapper;
+    private final HttpClient httpClient;
+
+    public GlossaryService(GlossaryTermRepository repo, ObjectMapper mapper) {
+        this.repo = repo;
+        this.mapper = mapper;
+        this.httpClient = HttpClient.newHttpClient();
+    }
+
+    public GlossaryDTO search(String term) {
+        // 1) DB 검색
+        Optional<GlossaryTerm> opt = repo.findByTermContainingIgnoreCase(term).stream().findFirst();
+        if (opt.isPresent()) {
+            GlossaryTerm gt = opt.get();
+            return new GlossaryDTO(gt.getTerm(), gt.getDefinition(), "DB", null);
+        }
+
+        // 2) Wikipedia API로 직접 해당 용어의 정의를 요청 (page/summary)
+        try {
+            String urlTerm = URLEncoder.encode(term, StandardCharsets.UTF_8);
+            String url = "https://ko.wikipedia.org/api/rest_v1/page/summary/" + urlTerm;
+            HttpRequest req = HttpRequest.newBuilder()
+                    .uri(URI.create(url))
+                    .header("Accept", "application/json")
+                    .build();
+            HttpResponse<String> resp = httpClient.send(req, HttpResponse.BodyHandlers.ofString());
+
+            // 2.1) 정상 응답인 경우
+            if (resp.statusCode() == 200) {
+                JsonNode root = mapper.readTree(resp.body());
+                String extract = root.path("extract").asText("");
+                String pageUrl = root.path("content_urls")
+                        .path("desktop")
+                        .path("page")
+                        .asText(null);
+                if (!extract.isBlank()) {
+                    return new GlossaryDTO(term, extract, "Wikipedia", pageUrl);
+                }
+            }
+
+            // 2.2) 해당 용어가 없으면 검색 API를 통해 유사한 용어 검색
+            if (resp.statusCode() == 404) {
+                String searchUrl = "https://ko.wikipedia.org/w/api.php?action=query&list=search&srsearch=" + URLEncoder.encode(term, StandardCharsets.UTF_8) + "&format=json";
+                HttpRequest searchReq = HttpRequest.newBuilder()
+                        .uri(URI.create(searchUrl))
+                        .header("Accept", "application/json")
+                        .build();
+                HttpResponse<String> searchResp = httpClient.send(searchReq, HttpResponse.BodyHandlers.ofString());
+
+                if (searchResp.statusCode() == 200) {
+                    JsonNode searchRoot = mapper.readTree(searchResp.body());
+                    JsonNode searchResults = searchRoot.path("query").path("search");
+
+                    // 2.3) 가장 첫 번째 검색된 용어로 다시 page/summary 호출
+                    if (searchResults.isArray() && searchResults.size() > 0) {
+                        String bestTitle = searchResults.get(0).path("title").asText();
+                        String fallbackUrl = "https://ko.wikipedia.org/api/rest_v1/page/summary/" + URLEncoder.encode(bestTitle, StandardCharsets.UTF_8);
+                        HttpRequest fallbackReq = HttpRequest.newBuilder()
+                                .uri(URI.create(fallbackUrl))
+                                .header("Accept", "application/json")
+                                .build();
+                        HttpResponse<String> fallbackResp = httpClient.send(fallbackReq, HttpResponse.BodyHandlers.ofString());
+
+                        if (fallbackResp.statusCode() == 200) {
+                            JsonNode fallbackRoot = mapper.readTree(fallbackResp.body());
+                            String fallbackExtract = fallbackRoot.path("extract").asText("");
+                            String fallbackPageUrl = fallbackRoot.path("content_urls")
+                                    .path("desktop")
+                                    .path("page")
+                                    .asText(null);
+                            if (!fallbackExtract.isBlank()) {
+                                return new GlossaryDTO(term, fallbackExtract, "Wikipedia", fallbackPageUrl);
+                            }
+                        }
+                    }
+                }
+            }
+
+        } catch (Exception e) {
+            // 예외 처리 (로깅만)
+            e.printStackTrace();
+        }
+
+        // 3) 둘 다 실패한 경우
+        return null;
+    }
+}

--- a/src/main/java/com/example/mockvoting/domain/youtube/controller/YoutubeController.java
+++ b/src/main/java/com/example/mockvoting/domain/youtube/controller/YoutubeController.java
@@ -1,5 +1,6 @@
 package com.example.mockvoting.domain.youtube.controller;
 
+import com.example.mockvoting.domain.youtube.service.YoutubeService;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -10,23 +11,16 @@ import org.springframework.web.client.RestTemplate;
 @RequestMapping("/api/youtube")
 public class YoutubeController {
 
+    private final YoutubeService youtubeService;
 
-    @Value("${youtube.api.key}")
-    private String apiKey;
-
-    private final RestTemplate restTemplate = new RestTemplate();
+    public YoutubeController(YoutubeService youtubeService) {
+        this.youtubeService = youtubeService;
+    }
 
     @GetMapping("/videos")
     public ResponseEntity<?> getYoutubeVideos(@RequestParam String query) {
-        String url = "https://www.googleapis.com/youtube/v3/search"
-                + "?part=snippet"
-                + "&q=" + query
-                + "&key=" + apiKey
-                + "&type=video"
-                + "&maxResults=10";
-
         try {
-            String response = restTemplate.getForObject(url, String.class);
+            String response = youtubeService.getVideos(query);
             return ResponseEntity.ok(response);
         } catch (Exception e) {
             return ResponseEntity
@@ -35,3 +29,4 @@ public class YoutubeController {
         }
     }
 }
+

--- a/src/main/java/com/example/mockvoting/domain/youtube/entity/YoutubeCache.java
+++ b/src/main/java/com/example/mockvoting/domain/youtube/entity/YoutubeCache.java
@@ -1,0 +1,25 @@
+package com.example.mockvoting.domain.youtube.entity;
+
+import jakarta.persistence.*;
+import lombok.Data;
+
+import java.time.LocalDateTime;
+
+@Data
+@Entity
+@Table(name = "youtube_cache")
+public class YoutubeCache {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(unique = true)
+    private String query;
+
+    @Lob
+    private String response;
+
+    private LocalDateTime cachedAt;
+}
+

--- a/src/main/java/com/example/mockvoting/domain/youtube/repository/YoutubeCacheRepository.java
+++ b/src/main/java/com/example/mockvoting/domain/youtube/repository/YoutubeCacheRepository.java
@@ -1,0 +1,10 @@
+package com.example.mockvoting.domain.youtube.repository;
+
+import com.example.mockvoting.domain.youtube.entity.YoutubeCache;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface YoutubeCacheRepository extends JpaRepository<YoutubeCache, Long> {
+    Optional<YoutubeCache> findByQuery(String query);
+}

--- a/src/main/java/com/example/mockvoting/domain/youtube/service/YoutubeService.java
+++ b/src/main/java/com/example/mockvoting/domain/youtube/service/YoutubeService.java
@@ -1,0 +1,56 @@
+package com.example.mockvoting.domain.youtube.service;
+
+import com.example.mockvoting.domain.youtube.entity.YoutubeCache;
+import com.example.mockvoting.domain.youtube.repository.YoutubeCacheRepository;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestTemplate;
+
+import java.time.Duration;
+import java.time.LocalDateTime;
+import java.util.Optional;
+
+@Service
+public class YoutubeService {
+
+    @Value("${youtube.api.key}")
+    private String apiKey;
+
+    private final YoutubeCacheRepository cacheRepository;
+    private final RestTemplate restTemplate = new RestTemplate();
+
+    private final Duration ttl = Duration.ofMinutes(30); // TTL: 30분
+
+    public YoutubeService(YoutubeCacheRepository cacheRepository) {
+        this.cacheRepository = cacheRepository;
+    }
+
+    public String getVideos(String query) {
+        Optional<YoutubeCache> optionalCache = cacheRepository.findByQuery(query);
+
+        if (optionalCache.isPresent()) {
+            YoutubeCache cache = optionalCache.get();
+            if (cache.getCachedAt().isAfter(LocalDateTime.now().minus(ttl))) {
+                return cache.getResponse(); // ✅ 캐시 유효, 반환
+            }
+        }
+
+        // ⛔ 캐시 없음 or 만료 → API 호출
+        String url = "https://www.googleapis.com/youtube/v3/search"
+                + "?part=snippet"
+                + "&q=" + query
+                + "&key=" + apiKey
+                + "&type=video"
+                + "&maxResults=10";
+
+        String response = restTemplate.getForObject(url, String.class);
+
+        YoutubeCache newCache = optionalCache.orElse(new YoutubeCache());
+        newCache.setQuery(query);
+        newCache.setResponse(response);
+        newCache.setCachedAt(LocalDateTime.now());
+        cacheRepository.save(newCache);
+
+        return response;
+    }
+}


### PR DESCRIPTION
WikipediaAPI 검색 사전 구현

실행 순서

1. DB에서 찾은 경우: 정의를 DB에서 바로 반환
2. Wikipedia에서 찾은 경우: page/summary로 해당 용어를 바로 찾아 정의를 반환
3. Wikipedia에서 못 찾은 경우: **search API**로 관련 문서를 검색하고, 그 중 첫 번째 결과에 대한 정의를 **page/summary API**로 다시 요청하여 반환

따라서 사용자가 정확하지 않은 용어나 합성어를 입력하더라도 관련 설명을 제공받을 수 있도록 유사 검색 기능 추가

YouTube API 캐싱 처리 및 예외 대응 개선

주요 변경사항

- YouTube Data API 호출 시 발생하는 쿼터 초과 오류(403) 대응 로직 추가
- RestTemplate 예외 처리 개선 → 실제 HTTP 상태 코드(403 등)를 그대로 반환하도록 수정
- API 호출 결과를 MySQL에 캐싱하여 동일 쿼리에 대해 반복 호출 방지
- 프론트엔드에서 영상 리스트 요청 시 백엔드 캐시 확인 후, 없을 경우에만 외부 API 호출
- 쿼터 초과 시에도 사용자에게 안정적인 응답 제공 (500 오류 대신 설명 포함된 메시지 반환)

구현 상세

1. /api/youtube/videos?query=검색어 → MySQL 캐시 확인 → 없을 경우만 YouTube API 호출
2. API 응답 결과는 검색어 기준으로 DB에 저장하여 재사용
3. RestTemplate 예외를 HttpClientErrorException으로 분기 처리하여 상태 코드 구분