### PR TITLE
게시글 삭제 및 첨부파일 표시 기능 개선

### DIFF
--- a/src/main/java/com/example/mockvoting/domain/community/controller/PostController.java
+++ b/src/main/java/com/example/mockvoting/domain/community/controller/PostController.java
@@ -6,6 +6,7 @@ import com.example.mockvoting.domain.community.dto.PostDetailViewDTO;
 import com.example.mockvoting.domain.community.dto.PostSummaryResponseDTO;
 import com.example.mockvoting.domain.community.service.PostService;
 import com.example.mockvoting.response.ApiResponse;
+import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -79,7 +80,7 @@ public class PostController {
      *  게시글 등록
      */
     @PostMapping(consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
-    public ResponseEntity<ApiResponse<Long>> createPost(@RequestPart PostCreateRequestDTO dto,
+    public ResponseEntity<ApiResponse<Long>> create(@RequestPart PostCreateRequestDTO dto,
                                                         @RequestPart(value="attachments", required = false) List<MultipartFile> attachments
     ) {
         log.info("게시글 등록 요청: {}", dto.getTitle());
@@ -93,4 +94,26 @@ public class PostController {
             return ResponseEntity.internalServerError().body(ApiResponse.error("게시글 등록 실패"));
         }
     }
+
+    /**
+     *  게시글 삭제
+     */
+    @DeleteMapping("/{id}")
+    public ResponseEntity<ApiResponse<Void>> delete(@PathVariable Long id, HttpServletRequest request) {
+        String userId = (String) request.getAttribute("userId");
+        log.info("게시글 삭제 요청: postId={}, 요청자={}", id, userId);
+
+        try {
+            postService.delete(id, userId);
+            log.info("게시글 삭제 요청 처리 성공: postId={}", id);
+            return ResponseEntity.ok(ApiResponse.success("게시글 삭제 성공", null));
+        } catch (SecurityException e) {
+            log.warn("게시글 삭제 권한 없음: postId={}, 요청자={}", id, userId);
+            return ResponseEntity.status(403).body(ApiResponse.error("게시글 삭제 권한이 없습니다."));
+        } catch (Exception e) {
+            log.error("게시글 삭제 요청 처리 실패: postId={}, 요청자={}", id, userId, e);
+            return ResponseEntity.internalServerError().body(ApiResponse.error("게시글 삭제 실패"));
+        }
+    }
+
 }

--- a/src/main/java/com/example/mockvoting/domain/community/dto/PostDetailResponseDTO.java
+++ b/src/main/java/com/example/mockvoting/domain/community/dto/PostDetailResponseDTO.java
@@ -27,4 +27,5 @@ public class PostDetailResponseDTO {
     private String categoryName;
     private String authorNickname;
     private List<PostAttachmentResponseDTO> attachments;
+    private Integer commentCount;
 }

--- a/src/main/java/com/example/mockvoting/domain/community/entity/Post.java
+++ b/src/main/java/com/example/mockvoting/domain/community/entity/Post.java
@@ -51,7 +51,7 @@ public class Post {
     private LocalDateTime updatedAt;
 
     @Column(name = "is_deleted", nullable = false)
-    private boolean isDeleted;
+    private boolean deleted;
 
     @PrePersist
     protected void onCreate() {

--- a/src/main/java/com/example/mockvoting/domain/community/entity/PostAttachment.java
+++ b/src/main/java/com/example/mockvoting/domain/community/entity/PostAttachment.java
@@ -36,7 +36,7 @@ public class PostAttachment {
     private LocalDateTime createdAt;
 
     @Column(name = "is_deleted", nullable = false)
-    private Boolean isDeleted = false;
+    private boolean deleted = false;
 
     @PrePersist
     protected void onCreate() {

--- a/src/main/java/com/example/mockvoting/domain/community/repository/PostAttachmentRepository.java
+++ b/src/main/java/com/example/mockvoting/domain/community/repository/PostAttachmentRepository.java
@@ -3,5 +3,8 @@ package com.example.mockvoting.domain.community.repository;
 import com.example.mockvoting.domain.community.entity.PostAttachment;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+
 public interface PostAttachmentRepository extends JpaRepository<PostAttachment, Long> {
+    List<PostAttachment> findByPostId(Long postId);
 }

--- a/src/main/java/com/example/mockvoting/domain/community/service/PostService.java
+++ b/src/main/java/com/example/mockvoting/domain/community/service/PostService.java
@@ -118,7 +118,7 @@ public class PostService {
                         .name(file.getOriginalFilename())
                         .url(url)
                         .size(file.getSize())
-                        .isDeleted(false)
+                        .deleted(false)
                         .build();
 
                 postAttachmentRepository.save(attachment);
@@ -126,5 +126,28 @@ public class PostService {
         }
 
         return id;
+    }
+
+    /**
+     *  게시글 삭제
+     */
+    @Transactional
+    public void delete(Long postId, String requesterId) {
+        // 게시글 존재 확인 및 소유자 확인
+        Post post = postRepository.findById(postId)
+                .orElseThrow(() -> new IllegalArgumentException("게시글이 존재하지 않습니다"));
+
+        if (!post.getAuthorId().equals(requesterId)) {
+            throw new SecurityException("게시글 삭제 권한이 없습니다");
+        }
+
+        // 게시글 soft delete
+        post.setDeleted(true);
+
+        // 첨부파일 soft delete
+        List<PostAttachment> attachments = postAttachmentRepository.findByPostId(postId);
+        for (PostAttachment attachment : attachments) {
+            attachment.setDeleted(true);
+        }
     }
 }

--- a/src/main/resources/mapper/PostMapper.xml
+++ b/src/main/resources/mapper/PostMapper.xml
@@ -16,7 +16,13 @@
             post.updated_at,
             category.code AS category_code,
             category.name AS category_name,
-            user.nickname AS author_nickname
+            user.nickname AS author_nickname,
+            (
+                SELECT COUNT(*)
+                FROM post_comment
+                WHERE post_comment.post_id = post.id
+                  AND post_comment.is_deleted = FALSE
+            ) AS comment_count
         FROM post
                  LEFT JOIN category ON post.category_id = category.id
                  LEFT JOIN user ON post.author_id = user.user_id


### PR DESCRIPTION
## 게시글 삭제 및 첨부파일 표시 기능 개선

### 주요 변경 사항
- 게시글 삭제 기능 구현  
  - `PostService`에 `delete()` 메서드 추가  
  - 게시글 삭제 시 `Post.deleted = true` 처리 (soft delete 방식 적용)  
  - 관련 첨부파일도 `PostAttachment.deleted = true`로 처리되도록 연동  
  - 삭제 요청 이후 커뮤니티 메인으로 이동 처리 (`PostDetail.jsx`)
- PostAttachment 조회 기능 추가  
  - `PostAttachmentRepository.findByPostId()` 메서드 신규 작성  
- boolean 필드명 변경  
  - `isDeleted` → `deleted`로 필드명 통일 (Lombok getter 충돌 방지 목적)  
  - 관련 빌더 및 서비스 내부 코드도 모두 일괄 반영
- 권한 기반 UI 처리  
  - 로그인 사용자와 작성자가 동일한 경우에만 수정/삭제 버튼 노출되도록 조건부 렌더링 적용

### 변경 배경
- soft delete 방식을 통해 게시글/첨부파일의 데이터 보존 가능
- boolean 필드명이 `isDeleted`일 경우 Lombok getter와 충돌 발생해 사용이 안되는 문제 발생
- UI 상에서 권한 없이 버튼 노출되는 문제 방지

### 테스트 방법
- 게시글 삭제 시 DB에서 `Post.deleted` 및 `PostAttachment.deleted`가 true로 변경되는지 확인  
- 삭제된 게시글이 목록 및 상세 페이지에서 더 이상 조회되지 않는지 확인  
- 작성자가 아닐 경우 삭제 버튼이 노출되지 않는지 확인  
- 첨부파일 이름 및 처리에 이상 없는지, 길이가 긴 경우 UI에서 정상적으로 `...` 처리되는지 확인
