### PR TITLE
Redis 조회수 처리 로직 주석 처리 (로컬 개발 대응)

### DIFF
--- a/src/main/java/com/example/mockvoting/domain/community/service/PostService.java
+++ b/src/main/java/com/example/mockvoting/domain/community/service/PostService.java
@@ -63,16 +63,17 @@ public class PostService {
 //                    : viewedPostIds + "-" + id;
 //        }
 
-        boolean alreadyViewed = false;
-        if (userId != null) {
-            String key = "viewed:" + userId;
-            alreadyViewed = Boolean.TRUE.equals(stringRedisTemplate.opsForSet().isMember(key, id.toString()));
-            if (!alreadyViewed) {
-                postMapper.updateViewCountById(id);
-                stringRedisTemplate.opsForSet().add(key, id.toString());
-                stringRedisTemplate.expire(key, Duration.ofHours(12));
-            }
-        }
+        // 반드시 수정 필요 일단 주석 처리
+//        boolean alreadyViewed = false;
+//        if (userId != null) {
+//            String key = "viewed:" + userId;
+//            alreadyViewed = Boolean.TRUE.equals(stringRedisTemplate.opsForSet().isMember(key, id.toString()));
+//            if (!alreadyViewed) {
+//                postMapper.updateViewCountById(id);
+//                stringRedisTemplate.opsForSet().add(key, id.toString());
+//                stringRedisTemplate.expire(key, Duration.ofHours(12));
+//            }
+//        }
 
         // 4) 게시글 조회
         PostDetailResponseDTO detail = postMapper.selectPostDetailById(id);


### PR DESCRIPTION
## Redis 조회수 처리 로직 주석 처리 (로컬 개발 대응)

### 주요 변경 사항
- PostService 내 Redis 기반 조회수 중복 방지 로직 주석 처리  
  - 로컬 환경에서 Redis 인스턴스가 동작하지 않아 개발 및 테스트 불가  
  - 임시로 관련 코드 주석 처리하여 전체 기능 정상 작동하도록 조치

### 변경 배경
- 로컬에서 Redis를 띄우지 못하는 상황에서도 게시글 상세 조회가 가능하도록 하기 위함  
- 배포 환경에서는 Redis 활성화 여부에 따라 다시 적용 예정

### 테스트 방법
- 게시글 상세 조회 시 오류 없이 조회수 증가 없이 정상 조회되는지 확인  
- Redis 미실행 상태에서도 서버 구동 및 게시글 조회 동작 확인
