### PR TITLE
도배 방지 및 캡챠 검증 기능 추가

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -236,6 +236,13 @@
 			<classifier>osx-aarch_64</classifier> <!-- 또는 osx-x86_64 -->
 		</dependency>
 
+		<!-- Apache Commons Text: 문자열 유사도 계산 (LevenshteinDistance) 용도 -->
+		<dependency>
+			<groupId>org.apache.commons</groupId>
+			<artifactId>commons-text</artifactId>
+			<version>1.12.0</version>
+		</dependency>
+
 	</dependencies>
 
 	<build>

--- a/src/main/java/com/example/mockvoting/domain/community/controller/PostController.java
+++ b/src/main/java/com/example/mockvoting/domain/community/controller/PostController.java
@@ -109,12 +109,14 @@ public class PostController {
      */
     @PostMapping(consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     public ResponseEntity<ApiResponse<Long>> create(@RequestPart PostCreateRequestDTO dto,
-                                                        @RequestPart(value="attachments", required = false) List<MultipartFile> attachments
+                                                    @RequestPart(value="attachments", required = false) List<MultipartFile> attachments,
+                                                    HttpServletRequest request
     ) {
-        log.info("게시글 등록 요청: {}", dto.getTitle());
+        String userId = (String) request.getAttribute("userId");
+        log.info("게시글 등록 요청: {}", userId);
 
         try {
-            Long postId = postService.save(dto, attachments);
+            Long postId = postService.save(dto, attachments, userId);
             log.info("게시글 등록 요청 처리 성공: id={}", postId);
             return ResponseEntity.ok(ApiResponse.success("게시글 등록 성공", postId));
         } catch (Exception e) {

--- a/src/main/java/com/example/mockvoting/domain/community/dto/PostCreateRequestDTO.java
+++ b/src/main/java/com/example/mockvoting/domain/community/dto/PostCreateRequestDTO.java
@@ -16,4 +16,6 @@ public class PostCreateRequestDTO {
     private String content;
     private String authorId;
     private String thumbnailUrl;
+
+    private String captchaToken;
 }

--- a/src/main/java/com/example/mockvoting/domain/community/service/PostService.java
+++ b/src/main/java/com/example/mockvoting/domain/community/service/PostService.java
@@ -64,16 +64,16 @@ public class PostService {
 //        }
 
         // 반드시 수정 필요 일단 주석 처리
-        boolean alreadyViewed = false;
-        if (userId != null) {
-            String key = "viewed:" + userId;
-            alreadyViewed = Boolean.TRUE.equals(stringRedisTemplate.opsForSet().isMember(key, id.toString()));
-            if (!alreadyViewed) {
-                postMapper.updateViewCountById(id);
-                stringRedisTemplate.opsForSet().add(key, id.toString());
-                stringRedisTemplate.expire(key, Duration.ofHours(12));
-            }
-        }
+//        boolean alreadyViewed = false;
+//        if (userId != null) {
+//            String key = "viewed:" + userId;
+//            alreadyViewed = Boolean.TRUE.equals(stringRedisTemplate.opsForSet().isMember(key, id.toString()));
+//            if (!alreadyViewed) {
+//                postMapper.updateViewCountById(id);
+//                stringRedisTemplate.opsForSet().add(key, id.toString());
+//                stringRedisTemplate.expire(key, Duration.ofHours(12));
+//            }
+//        }
 
         // 4) 게시글 조회
         PostDetailResponseDTO detail = postMapper.selectPostDetailById(id);

--- a/src/main/java/com/example/mockvoting/domain/community/service/PostService.java
+++ b/src/main/java/com/example/mockvoting/domain/community/service/PostService.java
@@ -64,16 +64,16 @@ public class PostService {
 //        }
 
         // 반드시 수정 필요 일단 주석 처리
-//        boolean alreadyViewed = false;
-//        if (userId != null) {
-//            String key = "viewed:" + userId;
-//            alreadyViewed = Boolean.TRUE.equals(stringRedisTemplate.opsForSet().isMember(key, id.toString()));
-//            if (!alreadyViewed) {
-//                postMapper.updateViewCountById(id);
-//                stringRedisTemplate.opsForSet().add(key, id.toString());
-//                stringRedisTemplate.expire(key, Duration.ofHours(12));
-//            }
-//        }
+        boolean alreadyViewed = false;
+        if (userId != null) {
+            String key = "viewed:" + userId;
+            alreadyViewed = Boolean.TRUE.equals(stringRedisTemplate.opsForSet().isMember(key, id.toString()));
+            if (!alreadyViewed) {
+                postMapper.updateViewCountById(id);
+                stringRedisTemplate.opsForSet().add(key, id.toString());
+                stringRedisTemplate.expire(key, Duration.ofHours(12));
+            }
+        }
 
         // 4) 게시글 조회
         PostDetailResponseDTO detail = postMapper.selectPostDetailById(id);

--- a/src/main/java/com/example/mockvoting/domain/spamcheck/controller/SpamCheckController.java
+++ b/src/main/java/com/example/mockvoting/domain/spamcheck/controller/SpamCheckController.java
@@ -1,0 +1,46 @@
+package com.example.mockvoting.domain.spamcheck.controller;
+
+import com.example.mockvoting.domain.community.dto.CategoryResponseDTO;
+import com.example.mockvoting.domain.spamcheck.model.SpamCheckType;
+import com.example.mockvoting.domain.spamcheck.service.SpamCheckService;
+import com.example.mockvoting.response.ApiResponse;
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@Slf4j
+@RestController
+@RequestMapping("/api/spam-check")
+@RequiredArgsConstructor
+public class SpamCheckController {
+    private final SpamCheckService spamCheckService;
+
+    /**
+     * 도배 의심 여부 판단 (게시글/댓글 공용)
+     */
+    @PostMapping
+    public ResponseEntity<ApiResponse<Boolean>> checkSpam(@RequestParam SpamCheckType type,
+                                                          @RequestParam(required = false) String title,
+                                                          @RequestParam String content,
+                                                          HttpServletRequest request
+    ) {
+        String userId = (String) request.getAttribute("userId");
+        log.info("도배 판단 요청: userId={}, type={}", userId, type);
+
+        try {
+            boolean suspicious = spamCheckService.isSuspicious(userId, type, title, content);
+            log.info("도배 판단 요청 처리 성공: isSuspicious={}", suspicious);
+            return ResponseEntity.ok(ApiResponse.success("도배 판단 성공", suspicious));
+        } catch (Exception e) {
+            log.error("도배 판단 요청 처리 실패", e);
+            return ResponseEntity.internalServerError().body(ApiResponse.error("도배 판단 실패"));
+        }
+    }
+}

--- a/src/main/java/com/example/mockvoting/domain/spamcheck/dto/PostContentCheckDTO.java
+++ b/src/main/java/com/example/mockvoting/domain/spamcheck/dto/PostContentCheckDTO.java
@@ -1,0 +1,15 @@
+package com.example.mockvoting.domain.spamcheck.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class PostContentCheckDTO {
+    private String title;
+    private String content;
+}

--- a/src/main/java/com/example/mockvoting/domain/spamcheck/mapper/SpamCheckMapper.java
+++ b/src/main/java/com/example/mockvoting/domain/spamcheck/mapper/SpamCheckMapper.java
@@ -1,0 +1,18 @@
+package com.example.mockvoting.domain.spamcheck.mapper;
+
+import com.example.mockvoting.domain.spamcheck.dto.PostContentCheckDTO;
+import org.apache.ibatis.annotations.Mapper;
+import org.apache.ibatis.annotations.Param;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Mapper
+public interface SpamCheckMapper {
+    // 게시글: 최근 1분/10분 내 글 목록
+    List<PostContentCheckDTO> selectRecentPosts(@Param("userId") String userId,
+                                                @Param("since") LocalDateTime since);
+    // 댓글: 최근 1분/10분 내 댓글 목록
+    List<String> selectRecentComments(@Param("userId") String userId,
+                                      @Param("since") LocalDateTime since);
+}

--- a/src/main/java/com/example/mockvoting/domain/spamcheck/model/SpamCheckType.java
+++ b/src/main/java/com/example/mockvoting/domain/spamcheck/model/SpamCheckType.java
@@ -1,0 +1,8 @@
+package com.example.mockvoting.domain.spamcheck.model;
+
+public enum SpamCheckType {
+    POST,
+    POST_COMMENT,
+    FEED,
+    FEED_COMMENT
+}

--- a/src/main/java/com/example/mockvoting/domain/spamcheck/service/CaptchaService.java
+++ b/src/main/java/com/example/mockvoting/domain/spamcheck/service/CaptchaService.java
@@ -1,0 +1,64 @@
+package com.example.mockvoting.domain.spamcheck.service;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Service;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.client.RestTemplate;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class CaptchaService {
+    @Value("${recaptcha.secret}")
+    private String secretKey;
+
+    @Value("${recaptcha.verify-url}")
+    private String verifyUrl;
+
+    private final RestTemplate restTemplate = new RestTemplate();
+
+    /**
+     * 사용자가 제출한 캡챠 토큰을 구글 서버에 검증 요청하고,
+     * 검증 결과가 성공인지 여부를 반환
+     */
+    public boolean verifyToken(String token) {
+        if (token == null || token.isBlank()) {
+            return false;
+        }
+
+        // POST form-data 구성
+        MultiValueMap<String, String> requestData = new LinkedMultiValueMap<>();
+        requestData.add("secret", secretKey);
+        requestData.add("response", token);
+
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(MediaType.APPLICATION_FORM_URLENCODED);
+        HttpEntity<MultiValueMap<String, String>> entity = new HttpEntity<>(requestData, headers);
+
+        try {
+            ResponseEntity<RecaptchaResponse> response = restTemplate.postForEntity(
+                    verifyUrl, entity, RecaptchaResponse.class
+            );
+
+            boolean success = response.getBody() != null && response.getBody().success();
+            if (!success) {
+                log.warn("캡챠 인증 실패: {}", response.getBody());
+            }
+            log.info("캡챠 인증 성공");
+            return success;
+        } catch (Exception e) {
+            log.error("캡챠 인증 요청 실패", e);
+            return false;
+        }
+    }
+
+    // 내부 응답 매핑 클래스
+    private record RecaptchaResponse(boolean success, String challenge_ts, String hostname, float score, String action) {}
+}

--- a/src/main/java/com/example/mockvoting/domain/spamcheck/service/SpamCheckService.java
+++ b/src/main/java/com/example/mockvoting/domain/spamcheck/service/SpamCheckService.java
@@ -3,6 +3,7 @@ package com.example.mockvoting.domain.spamcheck.service;
 import com.example.mockvoting.domain.spamcheck.dto.PostContentCheckDTO;
 import com.example.mockvoting.domain.spamcheck.mapper.SpamCheckMapper;
 import com.example.mockvoting.domain.spamcheck.model.SpamCheckType;
+import com.example.mockvoting.util.SpamSimilarityUtil;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -15,6 +16,9 @@ public class SpamCheckService {
     private final SpamCheckMapper spamCheckMapper;
     private final SpamSimilarityUtil similarityUtil;
 
+    /**
+     * 도배 의심 여부 판단 (게시글/댓글 공용)
+     */
     public boolean isSuspicious(String userId, SpamCheckType type, String title, String content) {
         LocalDateTime now = LocalDateTime.now();
 
@@ -25,7 +29,7 @@ public class SpamCheckService {
             case POST_COMMENT -> spamCheckMapper.selectRecentComments(userId, oneMinuteAgo).size();
             default -> 0;
         };
-        if (recentCount >= 3) return true;
+        if (recentCount >= 2) return true;
 
         // 조건 2: 10분 내 유사 내용 여부
         LocalDateTime tenMinutesAgo = now.minusMinutes(10);
@@ -45,7 +49,7 @@ public class SpamCheckService {
                     if (similarityUtil.calculateSimilarity(current, prev) >= 0.8) return true;
                 }
             }
-            default -> {} // FEED 등은 추후 구현
+            default -> {}
         }
 
         return false;

--- a/src/main/java/com/example/mockvoting/domain/spamcheck/service/SpamCheckService.java
+++ b/src/main/java/com/example/mockvoting/domain/spamcheck/service/SpamCheckService.java
@@ -1,0 +1,53 @@
+package com.example.mockvoting.domain.spamcheck.service;
+
+import com.example.mockvoting.domain.spamcheck.dto.PostContentCheckDTO;
+import com.example.mockvoting.domain.spamcheck.mapper.SpamCheckMapper;
+import com.example.mockvoting.domain.spamcheck.model.SpamCheckType;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class SpamCheckService {
+    private final SpamCheckMapper spamCheckMapper;
+    private final SpamSimilarityUtil similarityUtil;
+
+    public boolean isSuspicious(String userId, SpamCheckType type, String title, String content) {
+        LocalDateTime now = LocalDateTime.now();
+
+        // 조건 1: 1분 내 작성 기록
+        LocalDateTime oneMinuteAgo = now.minusMinutes(1);
+        int recentCount = switch (type) {
+            case POST -> spamCheckMapper.selectRecentPosts(userId, oneMinuteAgo).size();
+            case POST_COMMENT -> spamCheckMapper.selectRecentComments(userId, oneMinuteAgo).size();
+            default -> 0;
+        };
+        if (recentCount >= 3) return true;
+
+        // 조건 2: 10분 내 유사 내용 여부
+        LocalDateTime tenMinutesAgo = now.minusMinutes(10);
+        String current = (title != null ? title : "") + content;
+
+        switch (type) {
+            case POST -> {
+                List<PostContentCheckDTO> recentPosts = spamCheckMapper.selectRecentPosts(userId, tenMinutesAgo);
+                for (PostContentCheckDTO post : recentPosts) {
+                    String combined = post.getTitle() + post.getContent();
+                    if (similarityUtil.calculateSimilarity(current, combined) >= 0.8) return true;
+                }
+            }
+            case POST_COMMENT -> {
+                List<String> recentComments = spamCheckMapper.selectRecentComments(userId, tenMinutesAgo);
+                for (String prev : recentComments) {
+                    if (similarityUtil.calculateSimilarity(current, prev) >= 0.8) return true;
+                }
+            }
+            default -> {} // FEED 등은 추후 구현
+        }
+
+        return false;
+    }
+}

--- a/src/main/java/com/example/mockvoting/util/SpamSimilarityUtil.java
+++ b/src/main/java/com/example/mockvoting/util/SpamSimilarityUtil.java
@@ -1,6 +1,8 @@
 package com.example.mockvoting.util;
 
 import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.text.similarity.LevenshteinDistance;
+import org.jsoup.Jsoup;
 import org.springframework.stereotype.Component;
 
 @Slf4j

--- a/src/main/java/com/example/mockvoting/util/SpamSimilarityUtil.java
+++ b/src/main/java/com/example/mockvoting/util/SpamSimilarityUtil.java
@@ -1,0 +1,33 @@
+package com.example.mockvoting.util;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+public class SpamSimilarityUtil {
+    private static final LevenshteinDistance DISTANCE = new LevenshteinDistance();
+
+    /**
+     * 문자열 유사도 계산 (0.0 ~ 1.0)
+     */
+    public double calculateSimilarity(String a, String b) {
+        if (a == null || b == null || a.isBlank() || b.isBlank()) return 0.0;
+
+        String cleanA = stripHtml(a);
+        String cleanB = stripHtml(b);
+
+        int maxLength = Math.max(cleanA.length(), cleanB.length());
+        if (maxLength == 0) return 1.0;
+
+        int distance = DISTANCE.apply(cleanA, cleanB);
+        return 1.0 - ((double) distance / maxLength);
+    }
+
+    /**
+     * HTML 태그 제거 후 순수 텍스트만 남김
+     */
+    private String stripHtml(String html) {
+        return Jsoup.parse(html).text().trim();
+    }
+}

--- a/src/main/resources/mapper/SpamCheckMapper.xml
+++ b/src/main/resources/mapper/SpamCheckMapper.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+<mapper namespace="com.example.mockvoting.domain.spamcheck.mapper.SpamCheckMapper">
+
+    <!-- 게시글: 최근 1분/10분 내 글 목록 -->
+    <select id="selectRecentPosts" resultType="com.example.mockvoting.domain.spamcheck.dto.PostContentCheckDTO">
+        SELECT title, content
+        FROM post
+        WHERE author_id = #{userId}
+          AND created_at >= #{since}
+          AND is_deleted = FALSE
+        ORDER BY created_at DESC
+    </select>
+
+    <!-- 댓글: 최근 1분/10분 내 댓글 목록 -->
+    <select id="selectRecentComments" resultType="String">
+        SELECT content
+        FROM post_comment
+        WHERE author_id = #{userId}
+          AND created_at >= #{since}
+          AND is_deleted = FALSE
+        ORDER BY created_at DESC
+    </select>
+
+
+</mapper>


### PR DESCRIPTION
## 도배 방지 및 캡챠 검증 기능 추가

### 주요 변경 사항
- `SpamCheckService`에서 게시글 작성 시 시간/유사도 기반 도배 의심 판단 로직 구현
  - 1분 이내 중복 작성 + 10분 이내 유사 내용 판별 기준 적용
  - 의심되면 응답에 `spamSuspected` 플래그 포함
- `CaptchaService` 구현 및 캡챠 토큰 검증 기능 추가 (Google reCAPTCHA)
  - 게시글 등록 시 캡챠 토큰을 함께 전송해 서버 측에서 유효성 검증 수행
- `PostController`, `PostService` 수정
  - 도배 판단 → 캡챠 필요 판단 → 캡챠 검증 흐름 통합
- `commons-text` 1.12.0 추가 (LevenshteinDistance 유사도 계산용)
- 댓글폼 중복 열림 방지 및 카테고리 UI 잘림 현상 등 세부 UI 수정 포함

### 변경 배경
- 도배성 게시글 및 스팸 방지를 위해 도배 의심 판단 로직 도입 필요
- 악의적 자동화 작성 방지를 위해 캡챠 검증 연동 필요

### 테스트 방법
1. 게시글 등록 시 동일/유사 내용 반복 작성 → 도배 의심 경고 및 캡챠 노출 확인
2. 캡챠 성공 후 게시글 정상 등록되는지 확인
3. 댓글 수정/답글 동시 폼 열기 제한 및 카테고리 UI 정상 출력 확인
