### PR TITLE
커뮤니티 메인 경로 인증 제외 처리

### DIFF
--- a/src/main/java/com/example/mockvoting/config/SecurityConfig.java
+++ b/src/main/java/com/example/mockvoting/config/SecurityConfig.java
@@ -45,6 +45,7 @@ public class SecurityConfig {
                         .requestMatchers("/api/users/oauth2/**").permitAll()
                         .requestMatchers("/api/polling/**").permitAll()
                         .requestMatchers("/api/youtube/**").permitAll()
+                        .requestMatchers(HttpMethod.GET,"/api/community/main").permitAll()
                         .requestMatchers("/api/community/categories/**").permitAll()
                         .requestMatchers(HttpMethod.GET, "/api/community/posts/*/edit").authenticated()
                         .requestMatchers(HttpMethod.GET, "/api/community/posts/**").permitAll()

--- a/src/main/java/com/example/mockvoting/security/JwtAuthorizationFilter.java
+++ b/src/main/java/com/example/mockvoting/security/JwtAuthorizationFilter.java
@@ -54,6 +54,7 @@ public class JwtAuthorizationFilter extends OncePerRequestFilter {
         String method = request.getMethod();
         if (path.startsWith("/api/users/oauth2/")||
                 path.equals("/api/youtube/videos") ||
+                path.equals("/api/community/main") ||
                 path.startsWith("/api/community/categories")||
                 (path.startsWith("/api/community/posts") && method.equals("GET") && !path.matches(".*/edit$"))||
                 (path.startsWith("/ws"))


### PR DESCRIPTION
## 커뮤니티 메인 경로 인증 제외 처리

### 주요 변경 사항
- `SecurityConfig` 수정하여 커뮤니티 메인 경로에 대해 인증 필터 적용 제외 설정 추가
- `JwtAuthorizationFilter`에서 해당 경로 요청 시 인증 처리 대상에서 제외되도록 반영

### 변경 배경
- 커뮤니티 메인 페이지는 비로그인 사용자도 접근 가능해야 하므로 인증 필터에서 제외 처리 필요

### 테스트 방법
1. 로그아웃 상태에서 커뮤니티 메인 접속 → 정상 진입되는지 확인
2. 인증이 필요한 다른 경로는 여전히 보호되는지 확인
